### PR TITLE
feat(ui): add configurable section order

### DIFF
--- a/kite.html
+++ b/kite.html
@@ -182,24 +182,108 @@
                 });
 
                 Alpine.store("sections", {
+                    defaultOrder: [
+                        "summary",
+                        "primaryImage",
+                        "highlights",
+                        "quotes",
+                        "secondaryImage",
+                        "perspectives",
+                        "historicalBackground",
+                        "humanitarianImpact",
+                        "technicalDetails",
+                        "businessAngle",
+                        "internationalReactions",
+                        "otherDetails",
+                        "timeline",
+                        "sources",
+                        "didYouKnow",
+                        "actionItems"
+                    ],
                     settings: {
                         summary: localStorage.getItem("showSummary") !== "false",
-                        images: localStorage.getItem("showImages") !== "false",
+                        primaryImage: localStorage.getItem("showPrimaryImage") !== "false",
                         highlights: localStorage.getItem("showHighlights") !== "false",
                         quotes: localStorage.getItem("showQuotes") !== "false",
+                        secondaryImage: localStorage.getItem("showSecondaryImage") !== "false",
                         perspectives: localStorage.getItem("showPerspectives") !== "false",
                         historicalBackground: localStorage.getItem("showHistoricalBackground") !== "false",
                         humanitarianImpact: localStorage.getItem("showHumanitarianImpact") !== "false",
                         technicalDetails: localStorage.getItem("showTechnicalDetails") !== "false",
                         businessAngle: localStorage.getItem("showBusinessAngle") !== "false",
                         internationalReactions: localStorage.getItem("showInternationalReactions") !== "false",
+                        otherDetails: localStorage.getItem("showOtherDetails") !== "false",
                         timeline: localStorage.getItem("showTimeline") !== "false",
+                        sources: localStorage.getItem("showSources") !== "false",
                         didYouKnow: localStorage.getItem("showDidYouKnow") !== "false",
                         actionItems: localStorage.getItem("showActionItems") !== "false"
                     },
+                    order: JSON.parse(localStorage.getItem("sectionOrder")),
                     toggle(section) {
                         this.settings[section] = !this.settings[section];
                         localStorage.setItem("show" + section.charAt(0).toUpperCase() + section.slice(1), this.settings[section]);
+                    },
+                    init() {
+                        if (!this.order) {
+                            this.order = this.defaultOrder;
+                        }
+                        // Reset if there are new items, or the keys are different
+                        if (this.order.length !== this.defaultOrder.length || Object.keys(this.order).some((key) => this.order[key] !== this.defaultOrder[key])) {
+                            this.order = this.defaultOrder;
+                            localStorage.setItem("sectionOrder", JSON.stringify(this.order));
+                        }
+                    },
+                    render() {
+                        const container = document.querySelector('[x-ref="sectionsList"]');
+                        
+                        // Clear existing content
+                        container.innerHTML = '';
+                        
+                        // Create the initial items
+                        Alpine.store('sections').order.forEach(sectionName => {
+                            const div = document.createElement('div');
+                            div.className = 'flex items-center justify-between';
+                            div.dataset.section = sectionName;
+                            div.innerHTML = `
+                                <div class='flex items-center'>
+                                    <svg class='w-6 h-6 text-gray-400 mr-3 cursor-move drag-handle' fill='none' stroke='currentColor' viewBox='0 0 24 24'>
+                                        <path stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M4 6h16M4 12h16M4 18h16'></path>
+                                    </svg>
+                                    <label class='text-sm font-medium text-gray-700 dark:text-gray-300'>
+                                        ${sectionName.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase())}
+                                    </label>
+                                </div>
+                                <button x-data 
+                                        @click="$store.sections.toggle('${sectionName}')" 
+                                        class="relative inline-flex h-6 w-11 items-center rounded-full"
+                                        :class="$store.sections.settings['${sectionName}'] ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
+                                    <span class='sr-only'>Toggle ${sectionName}</span>
+                                    <span class='inline-block h-4 w-4 transform rounded-full bg-white transition'
+                                        :class="$store.sections.settings['${sectionName}'] ? 'translate-x-6' : 'translate-x-1'"></span>
+                                </button>
+                            `;
+                            container.appendChild(div);
+                        });
+
+                        // Initialize Sortable
+                        new Sortable(container, {
+                            animation: 150,
+                            handle: '.drag-handle',
+                            onEnd: function(evt) {
+                                const newOrder = Array.from(evt.to.children)
+                                    .map(el => el.dataset.section)
+                                    .filter(Boolean);
+                                
+                                Alpine.store('sections').order = newOrder;
+                                localStorage.setItem("sectionOrder", JSON.stringify(newOrder));
+                            }
+                        });
+                    },
+                    reset() {
+                        this.order = this.defaultOrder;
+                        localStorage.setItem("sectionOrder", JSON.stringify(this.defaultOrder));
+
+                        this.render();
                     }
                 });
 
@@ -571,6 +655,7 @@
                         Alpine.store("theme").init();
                         Alpine.store("fontSize").init();
                         Alpine.store("storyCount").init();
+                        Alpine.store("sections").init();
 
                         fetchChaosIndex();
 
@@ -1277,31 +1362,36 @@
                                     </div>
                                 </div>
 
-                                <section x-show="story.expanded" class="py-4 bg-white dark:bg-dark-bg" @click.stop>
-                                    <p x-show="$store.sections.settings.summary" class="mb-6" x-text="story.short_summary"></p>
-                                    <p x-show="story.location" class="flex items-center text-gray-600 dark:text-gray-300 mb-6 cursor-pointer" @click="openMaps(story.location)" title="Open location in maps">
-                                        <img src="{{ static_path }}/svg/map.svg" alt="Map icon" class="w-5 h-5 mr-2" />
-                                        <span x-text="story.location"></span>
-                                    </p>
-                                    <figure x-show="story.articles.some(a => a.image) && $store.sections.settings.images" class="mb-6">
-                                        <div class="relative">
-                                            <template x-if="story.articles.find(a => a.image) && $store.sections.settings.images">
-                                                <div class="relative w-[calc(100%-1rem)] max-w-[800px] mx-auto">
-                                                    <a :href="story.articles.find(a => a.image).link" target="_blank" class="relative block">
-                                                        <img :src="story.articles.find(a => a.image).image" :alt="story.articles.find(a => a.image).image_caption || 'Story image'" class="w-full h-auto rounded-lg shadow-md" loading="lazy" />
-                                                        <div class="absolute bottom-2 right-2 bg-black bg-opacity-50 text-white text-sm px-2 py-1 rounded hover:bg-opacity-75">
-                                                            <span x-text="story.articles.find(a => a.image).domain"></span>
-                                                        </div>
-                                                    </a>
-                                                    <template x-if="story.articles.find(a => a.image).image_caption">
-                                                        <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 italic" x-text="story.articles.find(a => a.image).image_caption"></p>
-                                                    </template>
-                                                </div>
-                                            </template>
-                                        </div>
-                                    </figure>
+                                <section x-show="story.expanded" class="py-4 bg-white dark:bg-dark-bg flex flex-col" @click.stop x-effect="$store.sections.order">
+                                    <section x-show="$store.sections.settings.summary" :class="'order-' + $store.sections.order.indexOf('summary')" class="mt-6">
+                                        <p x-show="$store.sections.settings.summary" class="mb-6" x-text="story.short_summary"></p>
+                                        <p x-show="story.location" class="flex items-center text-gray-600 dark:text-gray-300 cursor-pointer" @click="openMaps(story.location)" title="Open location in maps">
+                                            <img src="{{ static_path }}/svg/map.svg" alt="Map icon" class="w-5 h-5 mr-2" />
+                                            <span x-text="story.location"></span>
+                                        </p>
+                                    </section>
 
-                                    <section x-show="$store.sections.settings.highlights">
+                                    <section x-show="story.articles.some(a => a.image) && $store.sections.settings.primaryImage" :class="'order-[' + $store.sections.order.indexOf('primaryImage') + ']'" class="mt-6"> 
+                                        <figure>
+                                            <div class="relative">
+                                                <template x-if="story.articles.find(a => a.image) && $store.sections.settings.primaryImage">
+                                                    <div class="relative w-[calc(100%-1rem)] max-w-[800px] mx-auto">
+                                                        <a :href="story.articles.find(a => a.image).link" target="_blank" class="relative block">
+                                                            <img :src="story.articles.find(a => a.image).image" :alt="story.articles.find(a => a.image).image_caption || 'Story image'" class="w-full h-auto rounded-lg shadow-md" loading="lazy" />
+                                                            <div class="absolute bottom-2 right-2 bg-black bg-opacity-50 text-white text-sm px-2 py-1 rounded hover:bg-opacity-75">
+                                                                <span x-text="story.articles.find(a => a.image).domain"></span>
+                                                            </div>
+                                                        </a>
+                                                        <template x-if="story.articles.find(a => a.image).image_caption">
+                                                            <p class="mt-2 text-sm text-gray-600 dark:text-gray-400 italic" x-text="story.articles.find(a => a.image).image_caption"></p>
+                                                        </template>
+                                                    </div>
+                                                </template>
+                                            </div>
+                                        </figure>
+                                    </section>
+
+                                    <section x-show="$store.sections.settings.highlights" :class="'order-[' + $store.sections.order.indexOf('highlights') + ']'" class="mt-6">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Highlights</h3>
                                         <div class="border-t border-dashed border-gray-300 dark:border-gray-600">
                                             <template x-for="(point, index) in story.talking_points" :key="point">
@@ -1327,7 +1417,7 @@
                                         </div>
                                     </section>
 
-                                    <section x-show="story.quote && $store.sections.settings.quotes" class="my-8 bg-[#F3F6FE] dark:bg-gray-700 rounded-lg p-4">
+                                    <section x-show="story.quote && $store.sections.settings.quotes" class="my-8 bg-[#F3F6FE] dark:bg-gray-700 rounded-lg p-4" :class="'order-[' + $store.sections.order.indexOf('quotes') + ']'">
                                         <blockquote class="text-lg text-black dark:text-white">
                                             <span x-text="story.quote"></span>
                                         </blockquote>
@@ -1343,8 +1433,8 @@
                                         </p>
                                     </section>
 
-                                    <section x-show="story.articles.filter(a => a.image).length >= 2 && $store.sections.settings.images" class="mt-6">
-                                        <template x-if="story.articles.filter(a => a.image)[1] && $store.sections.settings.images">
+                                    <section x-show="story.articles.filter(a => a.image).length >= 2 && $store.sections.settings.secondaryImage" class="mt-6" :class="'order-[' + $store.sections.order.indexOf('secondaryImage') + ']'">
+                                        <template x-if="story.articles.filter(a => a.image)[1] && $store.sections.settings.secondaryImage">
                                             <div class="relative w-[calc(100%-1rem)] max-w-[800px] mx-auto">
                                                 <a :href="story.articles.filter(a => a.image)[1].link" target="_blank" class="relative block">
                                                     <img
@@ -1364,7 +1454,7 @@
                                         </template>
                                     </section>
 
-                                    <section x-show="story.perspectives && story.perspectives.length > 0 && $store.sections.settings.perspectives" class="mt-6">
+                                    <section x-show="story.perspectives && story.perspectives.length > 0 && $store.sections.settings.perspectives" class="mt-6" :class="'order-[' + $store.sections.order.indexOf('perspectives') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mb-4">Perspectives</h3>
                                         <div class="flex flex-row overflow-x-auto gap-3 pb-4">
                                             <template x-for="(perspective, index) in story.perspectives" :key="index">
@@ -1388,19 +1478,19 @@
                                         </div>
                                     </section>
 
-                                    <section x-show="story.historical_background && $store.sections.settings.historicalBackground">
+                                    <section x-show="story.historical_background && $store.sections.settings.historicalBackground" :class="'order-[' + $store.sections.order.indexOf('historicalBackground') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Historical background</h3>
                                         <p class="mb-4 text-gray-700 dark:text-gray-300" x-text="story.historical_background"></p>
                                     </section>
 
-                                    <section x-show="story.humanitarian_impact && $store.sections.settings.humanitarianImpact">
+                                    <section x-show="story.humanitarian_impact && $store.sections.settings.humanitarianImpact" :class="'order-[' + $store.sections.order.indexOf('humanitarianImpact') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">
                                             Humanitarian impact
                                         </h3>
-                                        <p class="mb-4 text-gray-700 dark:text-gray-300" x-text="story.humanitarian_impact"></p>
+                                        <p class="mb-4 text-gray-700 dark:text-gray-300" x-text="story.humanitarian_impact" :class="'order-[' + $store.sections.order.indexOf('humanitarianImpact') + ']'"></p>
                                     </section>
 
-                                    <section x-show="story.technical_details && story.technical_details.length > 0 && $store.sections.settings.technicalDetails">
+                                    <section x-show="story.technical_details && story.technical_details.length > 0 && $store.sections.settings.technicalDetails" :class="'order-[' + $store.sections.order.indexOf('technicalDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Technical details</h3>
                                         <ul class="list-disc list-inside mb-4 text-gray-700 dark:text-gray-300 space-y-2">
                                             <template x-for="detail in story.technical_details" :key="detail">
@@ -1409,7 +1499,7 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="(story.business_angle_text || (story.business_angle_points && story.business_angle_points.length > 0)) && $store.sections.settings.businessAngle">
+                                    <section x-show="(story.business_angle_text || (story.business_angle_points && story.business_angle_points.length > 0)) && $store.sections.settings.businessAngle" :class="'order-[' + $store.sections.order.indexOf('businessAngle') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Business angle</h3>
                                         <p x-show="story.business_angle_text" class="mb-4 text-gray-700 dark:text-gray-300" x-text="story.business_angle_text"></p>
                                         <ul x-show="story.business_angle_points && story.business_angle_points.length > 0" class="list-disc list-inside mb-4 text-gray-700 dark:text-gray-300 space-y-2">
@@ -1419,7 +1509,7 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="story.international_reactions && story.international_reactions.length > 0 && $store.sections.settings.internationalReactions">
+                                    <section x-show="story.international_reactions && story.international_reactions.length > 0 && $store.sections.settings.internationalReactions" :class="'order-[' + $store.sections.order.indexOf('internationalReactions') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">
                                             International reactions
                                         </h3>
@@ -1443,7 +1533,7 @@
                                         </div>
                                     </section>
 
-                                    <section x-show="story.scientific_significance && story.scientific_significance.length > 0">
+                                    <section x-show="story.scientific_significance && story.scientific_significance.length > 0 && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Scientific significance</h3>
                                         <ul class="list-disc list-inside mb-4 text-gray-700 dark:text-gray-300 space-y-2">
                                             <template x-for="point in story.scientific_significance" :key="point">
@@ -1452,7 +1542,7 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="story.travel_advisory && story.travel_advisory.length > 0">
+                                    <section x-show="story.travel_advisory && story.travel_advisory.length > 0 && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Travel advisory</h3>
                                         <ul class="list-disc list-inside mb-4 text-gray-700 dark:text-gray-300 space-y-2">
                                             <template x-for="point in story.travel_advisory" :key="point">
@@ -1461,7 +1551,7 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="story.performance_statistics && story.performance_statistics.length > 0">
+                                    <section x-show="story.performance_statistics && story.performance_statistics.length > 0 && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Performance statistics</h3>
                                         <ul class="list-disc list-inside mb-4 text-gray-700 dark:text-gray-300 space-y-2">
                                             <template x-for="stat in story.performance_statistics" :key="stat">
@@ -1470,17 +1560,17 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="story.league_standings">
+                                    <section x-show="story.league_standings && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">League standings</h3>
                                         <p class="mb-4 text-gray-700 dark:text-gray-300" x-text="story.league_standings"></p>
                                     </section>
 
-                                    <section x-show="story.design_principles">
+                                    <section x-show="story.design_principles && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Design principles</h3>
                                         <p class="mb-4 text-gray-700 dark:text-gray-300" x-text="story.design_principles"></p>
                                     </section>
 
-                                    <section x-show="story.user_experience_impact && story.user_experience_impact.length > 0">
+                                    <section x-show="story.user_experience_impact && story.user_experience_impact.length > 0 && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">User experience impact</h3>
                                         <ul class="list-disc list-inside mb-4 text-gray-700 dark:text-gray-300">
                                             <template x-for="impact in story.user_experience_impact" :key="impact">
@@ -1489,7 +1579,7 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="story.gameplay_mechanics && story.gameplay_mechanics.length > 0">
+                                    <section x-show="story.gameplay_mechanics && story.gameplay_mechanics.length > 0 && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Gameplay mechanics</h3>
                                         <ul class="list-disc list-inside mb-4 text-gray-700 dark:text-gray-300">
                                             <template x-for="mechanic in story.gameplay_mechanics" :key="mechanic">
@@ -1498,7 +1588,7 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="story.gaming_industry_impact && story.gaming_industry_impact.length > 0">
+                                    <section x-show="story.gaming_industry_impact && story.gaming_industry_impact.length > 0 && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Industry impact</h3>
                                         <ul class="list-disc list-inside mb-4 text-gray-700 dark:text-gray-300">
                                             <template x-for="impact in story.gaming_industry_impact" :key="impact">
@@ -1507,12 +1597,12 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="story.technical_specifications">
+                                    <section x-show="story.technical_specifications && $store.sections.settings.otherDetails" :class="'order-[' + $store.sections.order.indexOf('otherDetails') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200 mt-6 mb-2">Technical specifications</h3>
                                         <p class="mb-4 text-gray-700 dark:text-gray-300" x-text="story.technical_specifications"></p>
                                     </section>
 
-                                    <section x-show="story.timeline && story.timeline.length > 0 && $store.sections.settings.timeline">
+                                    <section x-show="story.timeline && story.timeline.length > 0 && $store.sections.settings.timeline" :class="'order-[' + $store.sections.order.indexOf('timeline') + ']'">
                                         <h2 class="timeline-title text-xl font-semibold mt-6 mb-4">Timeline of events</h2>
                                         <div class="timeline">
                                             <template x-for="(event, index) in story.timeline" :key="index">
@@ -1537,7 +1627,7 @@
                                     </section>
 
                                     <section x-data="{ showAllSources: false, visibleSources: window.innerWidth <= 768 ? 4 : 8 }" 
-                                             x-init="window.addEventListener('resize', () => { visibleSources = window.innerWidth <= 768 ? 4 : 8 })">
+                                            x-init="window.addEventListener('resize', () => { visibleSources = window.innerWidth <= 768 ? 4 : 8 })" x-show="$store.sections.settings.sources" :class="'order-[' + $store.sections.order.indexOf('sources') + ']'">
                                         <div class="flex items-center justify-between mt-6 mb-4">
                                             <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-200">Sources</h3>
                                             <button
@@ -1557,7 +1647,7 @@
                                                 </svg>
                                             </button>
                                         </div>
-                                        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                                        <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 mt-4">
                                             <template x-if="story.domains">
                                                 <template x-for="(domain, index) in story.domains" :key="index">
                                                     <button
@@ -1586,7 +1676,7 @@
                                         </div>
                                     </section>
 
-                                    <section x-show="story.user_action_items && story.user_action_items.length > 0 && $store.sections.settings.actionItems" class="bg-[#F1FAE8] dark:bg-[#2B411C] rounded-lg p-4 mt-6">
+                                    <section x-show="story.user_action_items && story.user_action_items.length > 0 && $store.sections.settings.actionItems" class="bg-[#F1FAE8] dark:bg-[#2B411C] rounded-lg p-4 mt-6" :class="'order-[' + $store.sections.order.indexOf('actionItems') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-2">Action items</h3>
                                         <ul class="list-disc ml-4 mb-2 text-gray-700 dark:text-gray-200 space-y-2">
                                             <template x-for="item in story.user_action_items" :key="item">
@@ -1595,12 +1685,12 @@
                                         </ul>
                                     </section>
 
-                                    <section x-show="story.did_you_know && $store.sections.settings.didYouKnow" class="bg-[#CED8FB] dark:bg-[#2A3B5E] rounded-lg p-4 mt-6">
+                                    <section x-show="story.did_you_know && $store.sections.settings.didYouKnow" class="bg-[#CED8FB] dark:bg-[#2A3B5E] rounded-lg p-4 mt-6" :class="'order-[' + $store.sections.order.indexOf('didYouKnow') + ']'">
                                         <h3 class="text-xl font-semibold text-gray-800 dark:text-gray-100 mb-2">Did you know?</h3>
                                         <p class="text-gray-700 dark:text-gray-200" x-text="story.did_you_know"></p>
                                     </section>
 
-                                    <div class="flex justify-center items-center space-x-4 mt-6 w-full md:px-0">
+                                    <div class="flex justify-center items-center space-x-4 mt-6 w-full md:px-0 order-last">
                                         <button
                                             @click.stop="shareArticle(story)"
                                             :data-share-url="window.location.origin + window.location.pathname + '?article=' + currentCategory.toLowerCase() + '-' + story.cluster_number"
@@ -1915,98 +2005,13 @@
                     </div>
                     <!-- Sections Tab -->
                     <div x-show="activeTab === 'sections'" class="space-y-6">
-                        <div class="flex flex-col space-y-4">
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Summary</label>
-                                <button @click="$store.sections.toggle('summary')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.summary ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle summary</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.summary ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Images</label>
-                                <button @click="$store.sections.toggle('images')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.images ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle images</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.images ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Highlights</label>
-                                <button @click="$store.sections.toggle('highlights')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.highlights ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle highlights</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.highlights ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Quotes</label>
-                                <button @click="$store.sections.toggle('quotes')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.quotes ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle quotes</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.quotes ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Perspectives</label>
-                                <button @click="$store.sections.toggle('perspectives')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.perspectives ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle perspectives</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.perspectives ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Historical background</label>
-                                <button @click="$store.sections.toggle('historicalBackground')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.historicalBackground ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle historical background</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.historicalBackground ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Humanitarian impact</label>
-                                <button @click="$store.sections.toggle('humanitarianImpact')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.humanitarianImpact ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle humanitarian impact</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.humanitarianImpact ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Technical details</label>
-                                <button @click="$store.sections.toggle('technicalDetails')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.technicalDetails ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle technical details</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.technicalDetails ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Business angle</label>
-                                <button @click="$store.sections.toggle('businessAngle')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.businessAngle ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle business angle</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.businessAngle ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">International reactions</label>
-                                <button @click="$store.sections.toggle('internationalReactions')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.internationalReactions ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle international reactions</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.internationalReactions ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Timeline</label>
-                                <button @click="$store.sections.toggle('timeline')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.timeline ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle timeline</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.timeline ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Did you know?</label>
-                                <button @click="$store.sections.toggle('didYouKnow')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.didYouKnow ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle did you know</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.didYouKnow ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
-                            <div class="flex items-center justify-between">
-                                <label class="text-sm font-medium text-gray-700 dark:text-gray-300">Action items</label>
-                                <button @click="$store.sections.toggle('actionItems')" class="relative inline-flex h-6 w-11 items-center rounded-full" :class="$store.sections.settings.actionItems ? 'bg-blue-600' : 'bg-gray-200 dark:bg-gray-700'">
-                                    <span class="sr-only">Toggle action items</span>
-                                    <span class="inline-block h-4 w-4 transform rounded-full bg-white transition" :class="$store.sections.settings.actionItems ? 'translate-x-6' : 'translate-x-1'"></span>
-                                </button>
-                            </div>
+                        <div class="flex flex-col space-y-4" x-ref="sectionsList" x-init="$store.sections.render()"></div>
+                        <!-- Reset button -->
+                        <div class="flex justify-center mt-4">
+                            <button @click="$store.sections.reset()" 
+                                    class="text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 text-sm">
+                                Reset order
+                            </button>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Made the section order configurable in the settings by dragging the individual sections around.

![chrome_ziJ7jXjrTU](https://github.com/user-attachments/assets/30bcd343-4388-4f0d-aa82-167b6f6e7944)