### PR TITLE
fix: truncate domain source names if they get too long.

### DIFF
--- a/kite.html
+++ b/kite.html
@@ -1732,7 +1732,7 @@
                                                 <template x-for="(domain, index) in story.domains" :key="index">
                                                     <button
                                                         x-show="index < visibleSources || showAllSources"
-                                                        class="flex flex-col items-start space-y-1 w-full text-left hover:bg-gray-100 dark:hover:bg-gray-700 p-2 rounded-lg transition-colors"
+                                                        class="flex flex-col items-start space-y-1 w-full text-left hover:bg-gray-100 dark:hover:bg-gray-700 py-2 pl-2 rounded-lg transition-colors"
                                                         @click.stop="$dispatch('open-source', { domain: domain, story: story })"
                                                         :aria-label="'Show articles from ' + (domain?.name || 'Unknown')"
                                                         :title="'Show articles from ' + (domain?.name || 'Unknown')"

--- a/kite.html
+++ b/kite.html
@@ -1746,7 +1746,7 @@
                                                                 class="w-5 h-5 rounded-full"
                                                                 loading="lazy"
                                                             />
-                                                            <span class="text-sm font-semibold" x-text="domain?.name || 'Unknown'"></span>
+                                                            <span class="text-sm font-semibold truncate" x-text="domain?.name || 'Unknown'"></span>
                                                         </div>
                                                         <span class="text-xs text-gray-500 dark:text-gray-400 ml-7" x-text="story?.articles ? (story.articles.filter(a => a.domain === domain?.name).length + ' articles') : '0 articles'">
                                                         </span>


### PR DESCRIPTION
Truncate domain source names if they get too long.

Before:
![image](https://github.com/user-attachments/assets/5729a8cf-e776-49ad-a96e-9d12a756fe38)
After:
![image](https://github.com/user-attachments/assets/5bb74aae-b83b-4d5e-a6d0-9006a108cb3d)