### PR TITLE
fix(ui): resolve intermittent category reordering and toggling issues on mobile

### DIFF
--- a/kite.html
+++ b/kite.html
@@ -785,9 +785,22 @@
                             isEnabled ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600'
                             }`;
                             div.dataset.category = categoryName;
-                            div.onclick = () => {
+
+
+                            // Use pointer workaround instead of click to avoid mobile browser issues
+                            let startTime = 0;
+                            div.addEventListener('pointerdown', (e) => {
+                                startTime = Date.now();
+                            });
+
+                            div.addEventListener('pointerup', (e) => {
+                                console.log("Pointer up", categoryName);
+                                // Only trigger click if the pointer was down for less than 200ms (distinguishes from drag)
+                                if (Date.now() - startTime < 200) {
                                 self.handleCategoryClick(categoryName);
-                            };
+                                }
+                            });
+
                                 
                             const displayName = categoryName === 'OnThisDay' ? 'Today in History' : categoryName;
                             div.innerHTML = `<span class='text-sm font-medium'>${displayName}</span>`;
@@ -806,8 +819,6 @@
                             .forEach(categoryName => {
                                 disabledContainer.appendChild(createCategoryElement(categoryName, false));
                             });
-                                                
-                        console.log("Categories rendered");
                     },
                     updateCategoryOrders(newEnabledOrder) {
                         const categoriesStore = Alpine.store("categories");

--- a/kite.html
+++ b/kite.html
@@ -10,7 +10,7 @@
         <link rel="apple-touch-icon" href="{{ static_path }}/apple-touch-icon.png" />
         <script src="https://cdn.tailwindcss.com"></script>
         <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
-        <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.4/Sortable.min.js"></script>
         <link rel="stylesheet" href="{{ static_path }}/kite.css?{{ timestamp }}" />
         <script>
             const timestamp = Date.now();
@@ -696,8 +696,8 @@
                                 }
 
                                 this.updateCategoryDropdown();
-                                this.renderCategoryUI();
-
+                                this.renderCategories();
+                                this.initCategorySortable();
                                 const articleId = getArticleIdFromUrl();
                                 if (articleId) {
                                     this.openSharedArticle(articleId);
@@ -754,50 +754,26 @@
                                 this.initialLoading = false;
                             });
                     },
-                    renderCategoryUI() {
-                        const enabledContainer = document.querySelector('#enabled-categories');
-                        const disabledContainer = document.querySelector('#disabled-categories');
-                        
-                        if (!enabledContainer || !disabledContainer) return;
-                        
-                        // Clear existing content
-                        enabledContainer.innerHTML = '';
-                        disabledContainer.innerHTML = '';
-                        
-                        const categoriesStore = Alpine.store('categories');
-                        
-                        // Helper function to create category element
-                        const createCategoryElement = (categoryName, isEnabled) => {
-                            const div = document.createElement('div');
-                            div.className = `px-4 py-3 rounded-md text-sm font-medium cursor-pointer flex items-center justify-center min-h-[48px] ${
-                                isEnabled ? 'bg-blue-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-600'
-                            }`;
-                            div.dataset.category = categoryName;
-                            div.onclick = () => {
-                                this.handleCategoryClick(categoryName);
-                            };
-                            
-                            const displayName = categoryName === 'OnThisDay' ? 'Today in History' : categoryName;
-                            div.innerHTML = `<span class='text-sm font-medium'>${displayName}</span>`;
-                            return div;
+                    createCategoryElement(categoryName, isEnabled) {
+                        const div = document.createElement('div');
+                        div.className = `px-4 py-3 rounded-md text-sm cursor-pointer font-medium flex items-center justify-center min-h-[48px] ${
+                            isEnabled ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600'
+                        }`;
+                        div.dataset.category = categoryName;
+                        div.onclick = () => {
+                            this.handleCategoryClick(categoryName);
                         };
-
-                        // Render enabled categories
-                        categoriesStore.enabled.forEach(categoryName => {
-                            enabledContainer.appendChild(createCategoryElement(categoryName, true));
-                        });
-
-                        // Render disabled categories
-                        this.availableCategories
-                            .map((cat) => cat.name)
-                            .filter(cat => !categoriesStore.enabled.includes(cat))
-                            .forEach(categoryName => {
-                                disabledContainer.appendChild(createCategoryElement(categoryName, false));
-                            });
-
-                        // Initialize Sortable only for enabled categories
+                            
+                        const displayName = categoryName === 'OnThisDay' ? 'Today in History' : categoryName;
+                        div.innerHTML = `<span class='text-sm font-medium'>${displayName}</span>`;
+                        return div;
+                    },
+                    initCategorySortable() {
+                        const enabledContainer = document.querySelector('[x-ref="enabledCategories"]');
                         new Sortable(enabledContainer, {
                             animation: 150,
+                            ghostClass: "bg-blue-600",
+                            swapThreshold: 0.5,
                             onEnd: (evt) => {
                                 const newEnabledOrder = Array.from(evt.to.children)
                                     .map(el => el.dataset.category)
@@ -806,6 +782,31 @@
                                 this.updateCategoryOrders(newEnabledOrder);
                             }
                         });
+                    },
+                    renderCategories() {
+                        const enabledContainer = document.querySelector('[x-ref="enabledCategories"]');
+                        const disabledContainer = document.querySelector('[x-ref="disabledCategories"]');
+                        const categoriesStore = Alpine.store('categories');
+                        
+                        // Clear existing content
+                        enabledContainer.innerHTML = '';
+                        disabledContainer.innerHTML = '';
+                        
+                        
+                        // Render enabled categories
+                        categoriesStore.enabled.forEach(categoryName => {
+                            enabledContainer.appendChild(this.createCategoryElement(categoryName, true));
+                        });
+                        
+                        // Render disabled categories
+                        this.availableCategories
+                            .map((cat) => cat.name)
+                            .filter(cat => !categoriesStore.enabled.includes(cat))
+                            .forEach(categoryName => {
+                                disabledContainer.appendChild(this.createCategoryElement(categoryName, false));
+                            });
+                                                
+                        console.log("Categories rendered");
                     },
                     updateCategoryOrders(newEnabledOrder) {
                         const categoriesStore = Alpine.store("categories");
@@ -845,7 +846,8 @@
                         localStorage.setItem("enabledCategories", JSON.stringify(categoriesStore.enabled));
                         
                         this.updateCategoryDropdown();
-                        this.renderCategoryUI();
+                        this.renderCategories();
+
                     },
                     updateCategoryDropdown() {
                         const select = document.getElementById("category-select");
@@ -2073,18 +2075,19 @@
                         </div>
                     </div>
                     <!-- Categories Tab -->
-                    <div x-show="activeTab === 'categories'" class="space-y-6" x-init="renderCategoryUI()">
+                    <div x-show="activeTab === 'categories'" class="space-y-6">
                         <div class="flex flex-col space-y-2">
                             <p class="text-xs text-gray-500 dark:text-gray-400">Tap to toggle. Drag enabled categories to reorder.</p>
 
                             <!-- Enabled categories grid -->
-                            <div id="enabled-categories" class="grid grid-cols-3 gap-3 mb-4" x-ref="enabledCategories"></div>
+                            <div x-ref="enabledCategories" class="grid grid-cols-3 gap-3 mb-4""></div>
 
                             <!-- Separator -->
                             <div class="border-t border-gray-200 dark:border-gray-700 my-4"></div>
 
                             <!-- Disabled categories grid -->
-                            <div id="disabled-categories" class="grid grid-cols-3 gap-3"></div>
+                            <div x-ref="disabledCategories" class="grid grid-cols-3 gap-3"></div>
+
                             <!-- Contribute link -->
                             <div class="flex justify-center mt-4">
                                 <a href="https://github.com/kagisearch/kite-public" class="text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 text-sm">

--- a/kite.html
+++ b/kite.html
@@ -754,20 +754,6 @@
                                 this.initialLoading = false;
                             });
                     },
-                    createCategoryElement(categoryName, isEnabled) {
-                        const div = document.createElement('div');
-                        div.className = `px-4 py-3 rounded-md text-sm cursor-pointer font-medium flex items-center justify-center min-h-[48px] ${
-                            isEnabled ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600'
-                        }`;
-                        div.dataset.category = categoryName;
-                        div.onclick = () => {
-                            this.handleCategoryClick(categoryName);
-                        };
-                            
-                        const displayName = categoryName === 'OnThisDay' ? 'Today in History' : categoryName;
-                        div.innerHTML = `<span class='text-sm font-medium'>${displayName}</span>`;
-                        return div;
-                    },
                     initCategorySortable() {
                         const enabledContainer = document.querySelector('[x-ref="enabledCategories"]');
                         new Sortable(enabledContainer, {
@@ -787,15 +773,30 @@
                         const enabledContainer = document.querySelector('[x-ref="enabledCategories"]');
                         const disabledContainer = document.querySelector('[x-ref="disabledCategories"]');
                         const categoriesStore = Alpine.store('categories');
+                        const self = this;
                         
                         // Clear existing content
                         enabledContainer.innerHTML = '';
                         disabledContainer.innerHTML = '';
                         
-                        
+                        function createCategoryElement(categoryName, isEnabled) {
+                            const div = document.createElement('div');
+                            div.className = `px-4 py-3 rounded-md text-sm cursor-pointer font-medium flex items-center justify-center min-h-[48px] ${
+                            isEnabled ? 'bg-blue-500 text-white' : 'bg-gray-100 text-gray-600'
+                            }`;
+                            div.dataset.category = categoryName;
+                            div.onclick = () => {
+                                self.handleCategoryClick(categoryName);
+                            };
+                                
+                            const displayName = categoryName === 'OnThisDay' ? 'Today in History' : categoryName;
+                            div.innerHTML = `<span class='text-sm font-medium'>${displayName}</span>`;
+                            return div;
+                        }
+
                         // Render enabled categories
                         categoriesStore.enabled.forEach(categoryName => {
-                            enabledContainer.appendChild(this.createCategoryElement(categoryName, true));
+                            enabledContainer.appendChild(createCategoryElement(categoryName, true));
                         });
                         
                         // Render disabled categories
@@ -803,7 +804,7 @@
                             .map((cat) => cat.name)
                             .filter(cat => !categoriesStore.enabled.includes(cat))
                             .forEach(categoryName => {
-                                disabledContainer.appendChild(this.createCategoryElement(categoryName, false));
+                                disabledContainer.appendChild(createCategoryElement(categoryName, false));
                             });
                                                 
                         console.log("Categories rendered");

--- a/kite.html
+++ b/kite.html
@@ -323,21 +323,24 @@
                 Alpine.store("categories", {
                     order: [],
                     enabled: [],
+                    isValidCategory(category){
+                        return category != null && category !== undefined && category !== "";
+                    },
                     init() {
                         const savedOrder = JSON.parse(localStorage.getItem("categoryOrder"));
                         const savedEnabled = JSON.parse(localStorage.getItem("enabledCategories"));
                         if (savedOrder) {
-                            this.order = savedOrder.filter((cat) => cat != null && cat !== undefined && cat !== "");
+                            this.order = savedOrder.filter((cat) => this.isValidCategory(cat));
                         }
                         if (savedEnabled) {
                             // Reorder enabled categories to match the order in categoryOrder and filter out null values
-                            this.enabled = this.order.filter((cat) => cat != null && cat !== undefined && cat !== "" && savedEnabled.includes(cat));
+                            this.enabled = this.order.filter((cat) => this.isValidCategory(cat) && savedEnabled.includes(cat));
                         }
                         // Save the cleaned up enabled categories
                         localStorage.setItem("enabledCategories", JSON.stringify(this.enabled));
                     },
-                    updateOrder(newOrder) {
-                        this.order = newOrder.filter((cat) => cat !== null && cat !== undefined && cat !== "");
+                    saveNewOrder(newOrder) {
+                        this.order = newOrder.filter((cat) => this.isValidCategory(cat));
                         // Don't modify enabled categories here - let the Sortable handler manage that
                         localStorage.setItem("categoryOrder", JSON.stringify(this.order));
                         localStorage.setItem("enabledCategories", JSON.stringify(this.enabled));
@@ -819,8 +822,7 @@
                         categoriesStore.order = newFullOrder;
 
                         // Update localStorage
-                        localStorage.setItem("enabledCategories", JSON.stringify(newEnabledOrder));
-                        localStorage.setItem("categoryOrder", JSON.stringify(newFullOrder));
+                        categoriesStore.saveNewOrder(newFullOrder);
 
                         // Update available categories
                         this.availableCategories = newFullOrder
@@ -829,12 +831,19 @@
                     },
                     handleCategoryClick(category) {
                         const categoriesStore = Alpine.store("categories");
-                        if (categoriesStore.enabled.length > 1 && !categoriesStore.enabled.includes(category)) {
+                        if (!categoriesStore.enabled.includes(category)) {
                             categoriesStore.enableCategory(category);
                         }
-                        else if(categoriesStore.enabled.includes(category)){
+                        else if(categoriesStore.enabled.length > 1 && categoriesStore.enabled.includes(category)){
                             categoriesStore.enabled = categoriesStore.enabled.filter(cat => cat !== category);
+                            if (category === this.currentCategory) { // If user disables current category, set to first enabled category
+                                this.currentCategory = categoriesStore.enabled[0];
+                                this.changeCategory();
+                            }
                         }
+
+                        localStorage.setItem("enabledCategories", JSON.stringify(categoriesStore.enabled));
+                        
                         this.updateCategoryDropdown();
                         this.renderCategoryUI();
                     },
@@ -859,13 +868,6 @@
                                 select.appendChild(option);
                             }
                         });
-
-                        // Ensure current category is the first enabled one
-                        const firstEnabledCategory = enabledCategories[0];
-                        if (firstEnabledCategory && firstEnabledCategory !== this.currentCategory) {
-                            this.currentCategory = firstEnabledCategory;
-                            this.changeCategory();
-                        }
                     },
                     closeIntro() {
                         this.showIntro = false;

--- a/kite.html
+++ b/kite.html
@@ -342,7 +342,7 @@
                         localStorage.setItem("categoryOrder", JSON.stringify(this.order));
                         localStorage.setItem("enabledCategories", JSON.stringify(this.enabled));
                     },
-                    toggle(category) {
+                    enableCategory(category) {
                         const index = this.enabled.indexOf(category);
                         if (index > -1) {
                             if (this.enabled.length > 1) {
@@ -358,7 +358,6 @@
                                 this.enabled.splice(insertIndex, 0, category);
                             }
                         }
-                        localStorage.setItem("enabledCategories", JSON.stringify(this.enabled));
                     },
                     isEnabled(category) {
                         return this.enabled.includes(category);
@@ -694,6 +693,7 @@
                                 }
 
                                 this.updateCategoryDropdown();
+                                this.renderCategoryUI();
 
                                 const articleId = getArticleIdFromUrl();
                                 if (articleId) {
@@ -707,10 +707,6 @@
                         Alpine.store("sections").init();
 
                         fetchChaosIndex();
-
-                        this.$nextTick(() => {
-                            this.initSortable();
-                        });
                     },
                     fetchCategories() {
                         return fetch(`{{ base_path }}kite.json?${timestamp}`)
@@ -755,75 +751,92 @@
                                 this.initialLoading = false;
                             });
                     },
-                    initSortable() {
-                        const el = document.getElementById("enabled-categories");
-                        if (el) {
-                            this.sortableInstance = new Sortable(el, {
-                                animation: 150,
-                                ghostClass: "bg-blue-600",
-                                forceFallback: false,
-                                fallbackClass: "sortable-fallback",
-                                setData: function () {
-                                    return false;
-                                },
-                                onStart: (evt) => {
-                                    evt.from.setAttribute("x-skip", "");
-                                },
-                                onEnd: (evt) => {
-                                    evt.from.removeAttribute("x-skip");
+                    renderCategoryUI() {
+                        const enabledContainer = document.querySelector('#enabled-categories');
+                        const disabledContainer = document.querySelector('#disabled-categories');
+                        
+                        if (!enabledContainer || !disabledContainer) return;
+                        
+                        // Clear existing content
+                        enabledContainer.innerHTML = '';
+                        disabledContainer.innerHTML = '';
+                        
+                        const categoriesStore = Alpine.store('categories');
+                        
+                        // Helper function to create category element
+                        const createCategoryElement = (categoryName, isEnabled) => {
+                            const div = document.createElement('div');
+                            div.className = `px-4 py-3 rounded-md text-sm font-medium cursor-pointer flex items-center justify-center min-h-[48px] ${
+                                isEnabled ? 'bg-blue-500 text-white' : 'bg-gray-100 dark:bg-gray-700 text-gray-600'
+                            }`;
+                            div.dataset.category = categoryName;
+                            div.onclick = () => {
+                                this.handleCategoryClick(categoryName);
+                            };
+                            
+                            const displayName = categoryName === 'OnThisDay' ? 'Today in History' : categoryName;
+                            div.innerHTML = `<span class='text-sm font-medium'>${displayName}</span>`;
+                            return div;
+                        };
 
-                                    const newEnabledOrder = Array.from(el.children)
-                                        .map((item) => item.dataset.category)
-                                        .filter(Boolean);
+                        // Render enabled categories
+                        categoriesStore.enabled.forEach(categoryName => {
+                            enabledContainer.appendChild(createCategoryElement(categoryName, true));
+                        });
 
-                                    const categoriesStore = Alpine.store("categories");
-
-                                    categoriesStore.enabled = [...newEnabledOrder];
-
-                                    const currentOrder = categoriesStore.order;
-                                    const newFullOrder = [...newEnabledOrder, ...currentOrder.filter((cat) => !newEnabledOrder.includes(cat))];
-                                    categoriesStore.order = [...newFullOrder];
-
-                                    localStorage.setItem("enabledCategories", JSON.stringify(newEnabledOrder));
-                                    localStorage.setItem("categoryOrder", JSON.stringify(newFullOrder));
-
-                                    this.availableCategories = newFullOrder.map((catName) => this.availableCategories.find((cat) => cat.name === catName)).filter(Boolean);
-
-                                    this.$nextTick(() => {
-                                        const sortableGrid = document.getElementById("enabled-categories");
-                                        if (sortableGrid) {
-                                            const newHTML = newEnabledOrder
-                                                .map(
-                                                    (catName) => `
-                                            <div data-category="${catName}" 
-                                                 class="bg-blue-500 text-white px-4 py-3 rounded-md text-sm font-medium cursor-pointer flex items-center justify-center min-h-[48px]">
-                                                <span>${catName}</span>
-                                            </div>
-                                        `
-                                                )
-                                                .join("");
-                                            sortableGrid.innerHTML = newHTML;
-                                        }
-
-                                        const categoryTabs = document.querySelector(".category-tabs");
-                                        if (categoryTabs) {
-                                            Alpine.morph(categoryTabs, categoryTabs.outerHTML);
-                                        }
-
-                                        this.sortableInstance.destroy();
-                                        this.initSortable();
-                                    });
-                                },
+                        // Render disabled categories
+                        this.availableCategories
+                            .map((cat) => cat.name)
+                            .filter(cat => !categoriesStore.enabled.includes(cat))
+                            .forEach(categoryName => {
+                                disabledContainer.appendChild(createCategoryElement(categoryName, false));
                             });
-                        }
+
+                        // Initialize Sortable only for enabled categories
+                        new Sortable(enabledContainer, {
+                            animation: 150,
+                            onEnd: (evt) => {
+                                const newEnabledOrder = Array.from(evt.to.children)
+                                    .map(el => el.dataset.category)
+                                    .filter(Boolean);
+                                
+                                this.updateCategoryOrders(newEnabledOrder);
+                            }
+                        });
+                    },
+                    updateCategoryOrders(newEnabledOrder) {
+                        const categoriesStore = Alpine.store("categories");
+                        const currentOrder = categoriesStore.order;
+
+                        // Update enabled categories
+                        categoriesStore.enabled = [...newEnabledOrder];
+
+                        // Create new full order maintaining positions
+                        const newFullOrder = [
+                            ...newEnabledOrder,
+                            ...currentOrder.filter(cat => !newEnabledOrder.includes(cat))
+                        ];
+                        categoriesStore.order = newFullOrder;
+
+                        // Update localStorage
+                        localStorage.setItem("enabledCategories", JSON.stringify(newEnabledOrder));
+                        localStorage.setItem("categoryOrder", JSON.stringify(newFullOrder));
+
+                        // Update available categories
+                        this.availableCategories = newFullOrder
+                            .map(catName => this.availableCategories.find(cat => cat.name === catName))
+                            .filter(Boolean);
                     },
                     handleCategoryClick(category) {
                         const categoriesStore = Alpine.store("categories");
-                        if (categoriesStore.enabled.length > 1) {
-                            categoriesStore.toggle(category.name);
-                            this.updateCategoryDropdown();
-                            this.changeCategory();
+                        if (categoriesStore.enabled.length > 1 && !categoriesStore.enabled.includes(category)) {
+                            categoriesStore.enableCategory(category);
                         }
+                        else if(categoriesStore.enabled.includes(category)){
+                            categoriesStore.enabled = categoriesStore.enabled.filter(cat => cat !== category);
+                        }
+                        this.updateCategoryDropdown();
+                        this.renderCategoryUI();
                     },
                     updateCategoryDropdown() {
                         const select = document.getElementById("category-select");
@@ -2058,37 +2071,18 @@
                         </div>
                     </div>
                     <!-- Categories Tab -->
-                    <div x-show="activeTab === 'categories'" class="space-y-6">
+                    <div x-show="activeTab === 'categories'" class="space-y-6" x-init="renderCategoryUI()">
                         <div class="flex flex-col space-y-2">
                             <p class="text-xs text-gray-500 dark:text-gray-400">Tap to toggle. Drag enabled categories to reorder.</p>
 
                             <!-- Enabled categories grid -->
-                            <div id="enabled-categories" class="grid grid-cols-3 gap-3 mb-4" x-ref="enabledCategories">
-                                <template x-for="category in availableCategories.filter(c => $store.categories.isEnabled(c.name))" :key="category.name">
-                                    <div
-                                        :data-category="category.name"
-                                        class="bg-blue-500 text-white px-4 py-3 rounded-md text-sm font-medium cursor-pointer flex items-center justify-center min-h-[48px]"
-                                        @click="handleCategoryClick(category)"
-                                    >
-                                        <span x-text="category.name"></span>
-                                    </div>
-                                </template>
-                            </div>
+                            <div id="enabled-categories" class="grid grid-cols-3 gap-3 mb-4" x-ref="enabledCategories"></div>
 
                             <!-- Separator -->
                             <div class="border-t border-gray-200 dark:border-gray-700 my-4"></div>
 
                             <!-- Disabled categories grid -->
-                            <div class="grid grid-cols-3 gap-3">
-                                <template x-for="category in availableCategories.filter(c => !$store.categories.isEnabled(c.name))" :key="category.name">
-                                    <div
-                                        :data-category="category.name"
-                                        class="bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-300 px-4 py-3 rounded-md text-sm font-medium cursor-pointer min-h-[48px] flex items-center justify-center"
-                                        @click="$store.categories.toggle(category.name); updateCategoryDropdown(); changeCategory();"
-                                        x-text="category.name"
-                                    ></div>
-                                </template>
-                            </div>
+                            <div id="disabled-categories" class="grid grid-cols-3 gap-3"></div>
                             <!-- Contribute link -->
                             <div class="flex justify-center mt-4">
                                 <a href="https://github.com/kagisearch/kite-public" class="text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 text-sm">


### PR DESCRIPTION
This PR addresses three related UI interaction issues affecting category management on WebKit and Chromium-based mobile browsers.

Steps to Reproduce:
1. Navigate to kite.kagi.com on a mobile device
2. Access Settings > Categories tab
3. Toggle issue:
   - Rapidly toggle multiple category switches in quick succession (e.g. using multi-touch)
   - Expected: UI remains responsive to all toggle interactions
   - Actual: UI becomes unresponsive until page refresh
4. For reordering issue:
   - Reorder any category using drag-and-drop
   - Attempt to toggle category switches
   - Expected: Toggles work normally after reordering
   - Actual: Toggle functionality breaks after reordering
5. For click event issue:
   - Attempt to toggle categories on affected systems
   - Expected: Toggle responds to click/tap
   - Actual: No response to click/tap interactions