### PR TITLE
fix: remove duplicate from Estonian feed

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -366,7 +366,6 @@
       "https://lounaeestlane.ee/feed/atom/",
       "https://www.internet.ee/eis/uudised.rss",
       "https://objektiiv.ee/feed/atom/",
-      "https://feeds.feedburner.com/aripaev-rss",
       "https://feeds2.feedburner.com/delfiuudised",
       "https://feeds2.feedburner.com/delfimaailm",
       "https://feeds2.feedburner.com/forteuudised",


### PR DESCRIPTION
The `https://www.aripaev.ee/rss` should be the only one.