### PR TITLE
Add New Zealand news feeds

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -932,5 +932,40 @@
       "https://www.reddit.com/r/Polska/.rss",
       "https://news.google.com/atom/topics/CAAqIQgKIhtDQkFTRGdvSUwyMHZNRFZ4YUhjU0FtVnVLQUFQAQ?hl=pl&gl=PL&ceid=PL%3Apl&oc=11",
     ]
+  },
+  "New Zealand": {
+    "feeds": [
+      "https://www.rnz.co.nz/rss/business.xml",
+      "https://www.rnz.co.nz/rss/country.xml",
+      "https://www.rnz.co.nz/rss/environment.xml",
+      "https://www.rnz.co.nz/rss/identity.xml",
+      "https://www.rnz.co.nz/rss/indonz.xml",
+      "https://www.rnz.co.nz/rss/ldr.xml",
+      "https://www.rnz.co.nz/rss/media-technology.xml",
+      "https://www.rnz.co.nz/rss/national.xml",
+      "https://www.rnz.co.nz/rss/pacific.xml",
+      "https://www.rnz.co.nz/rss/political.xml",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/curated/78/?outputType=xml&_website=nzh",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=nzh",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/business/?outputType=xml&_website=nzh",
+      "https://www.reddit.com/r/newzealand/.rss",
+      "https://www.stuff.co.nz/rss",
+      "https://www.theguardian.com/world/newzealand/rss",
+      "https://www.newstalkzb.co.nz/news/rssfeed",
+      "https://news.google.com/rss/topics/CAAqJggKIiBDQkFTRWdvSkwyMHZNR04wZDE5aUVnVmxiaTFIUWlnQVAB",
+      "https://www.scoop.co.nz/storyindex/index.rss?s.c=BU",
+      "https://www.scoop.co.nz/storyindex/index.rss?s.c=SC",
+      "https://www.scoop.co.nz/storyindex/index.rss?s.c=PA",
+      "https://www.scoop.co.nz/storyindex/index.rss?s.c=PO",
+      "https://www.scoop.co.nz/storyindex/index.rss?s.c=AK",
+      "https://www.scoop.co.nz/storyindex/index.rss?s.c=CU",
+      "https://www.scoop.co.nz/storyindex/index.rss?s.c=ED",
+      "https://www.scoop.co.nz/storyindex/index.rss?s.c=GE",
+      "https://newsroom.co.nz/feed/",
+      "https://www.odt.co.nz/news/feed",
+      "https://theconversation.com/nz/articles.atom",
+      "https://www.interest.co.nz/rss"
+
+    ]
   }
 }

--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -948,7 +948,6 @@
       "https://www.nzherald.co.nz/arc/outboundfeeds/rss/curated/78/?outputType=xml&_website=nzh",
       "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=nzh",
       "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/business/?outputType=xml&_website=nzh",
-      "https://www.reddit.com/r/newzealand/.rss",
       "https://www.stuff.co.nz/rss",
       "https://www.theguardian.com/world/newzealand/rss",
       "https://www.newstalkzb.co.nz/news/rssfeed",

--- a/media_data.json
+++ b/media_data.json
@@ -2370,5 +2370,13 @@
     "description": "Apache is a small independent investigative journalism platform in Belgium, focusing on in-depth reporting and analysis.",
     "owner": "Coöperatieve vennootschap",
     "typology": "Private Media"
+  },
+  {
+    "country": "New Zealand",
+    "organization": "Radio New Zealand",
+    "domains": ["rnz.co.nz"],
+    "description": "Radio New Zealand (RNZ) is New Zealand's independent public radio service. RNZ broadcasts three nationwide channels, RNZ National, RNZ Concert and the AM network (focused on parliamentary proceedings). RNZ Pacific (which used to operate as Radio New Zealand International or RNZI) is the group's international news broadcaster.",
+    "owner": "New Zealand Government",
+    "typology": "State Funded Media"
   }
 ]


### PR DESCRIPTION
This PR adds 29 RSS feeds for New Zealand although a number of them are for some of our main newspapers across different categories.

Unfortunately, a couple of our main TV broadcasters (TVNZ, One News) don't have RSS feeds but our main newspapers/journalism outlets do (NZ Herald and Stuff)

I've also added RNZ as a starting point to `media_data` but I'll go through and add all of the others at some future point since it'll take me a while to put the info together.

Please let me know if I need to include any other info.

EDIT: I've removed /r/newzealand as compared to other country subreddits like /r/australia, it doesn't share news links very often. /r/auckland is the same, almost always being text or image posts.