### PR TITLE
Add extra NZ feeds + fix media data for The Conversation

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -995,8 +995,18 @@
       "https://newsroom.co.nz/feed/",
       "https://www.odt.co.nz/news/feed",
       "https://theconversation.com/nz/articles.atom",
-      "https://www.interest.co.nz/rss"
-
+      "https://www.interest.co.nz/rss",
+      "https://www.teaonews.co.nz/arc/outboundfeeds/rss/",
+      "https://www.thepost.co.nz/rss",
+      "https://www.gisborneherald.co.nz/feed/rss",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=rotorua-daily-post",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=bay-of-plenty-times",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=northland-age",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=northern-advocate",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=waikato-news",
+      "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=whanganui-chronicle",
+      "https://www.thepress.co.nz/rss",
+      "https://www.waikatotimes.co.nz/rss"
     ]
   }
 }

--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1006,7 +1006,11 @@
       "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=waikato-news",
       "https://www.nzherald.co.nz/arc/outboundfeeds/rss/section/nz/?outputType=xml&_website=whanganui-chronicle",
       "https://www.thepress.co.nz/rss",
-      "https://www.waikatotimes.co.nz/rss"
+      "https://www.waikatotimes.co.nz/rss",
+      "https://www.reddit.com/r/newzealand/.rss",
+      "https://www.reddit.com/r/auckland/.rss",
+      "https://www.reddit.com/r/wellington/.rss",
+      "https://www.reddit.com/r/nzpolitics/.rss"
     ]
   }
 }

--- a/media_data.json
+++ b/media_data.json
@@ -2428,7 +2428,7 @@
     "typology": "Private Media"
   },
   {
-    "country": "New Zealand",
+    "country": "Australia",
     "organization": "The Conversation",
     "domains": ["theconversation.com"],
     "description": "The Conversation is a digital news and analysis platform that publishes articles written by academics and researchers, combining scholarly expertise with journalistic editing to provide in-depth coverage of current affairs, science, health, politics, and culture.",


### PR DESCRIPTION
This PR adds a number of NZ feeds, many of which are ultimately owned by NZME or Stuff Limited but it should flesh out a lot of local coverage.

I also realised that The Conversation is technically an Australian publication.

In the same vein as the discussion around subpaths, The Conversation uses subpaths for "editions" so eg; `theconversation.com/nz` covers NZ and the `/nz` subpath is present in the NZ Edition RSS feed.

As you'll spot, subpaths are also at play for many of the NZME (nzherald) feeds which appear on the web as distinct publications while clearly using the same CMS and website as the actual NZ Herald.

I'll be following up with media data but I'll need to see what (if any) changes are needed in the UI to properly support subpaths as mentioned in Discord.