### PR TITLE
Fix articles not opening between categories

### DIFF
--- a/kite.html
+++ b/kite.html
@@ -2025,7 +2025,7 @@
                         </div>
                     </template>
                     <template x-if="currentCategory !== 'OnThisDay'">
-                        <template x-for="(story, index) in stories" :key="story.cluster_number">
+                        <template x-for="(story, index) in stories" :key="story.category + story.cluster_number">
                             <article
                                 :id="'story-' + index"
                                 role="article"


### PR DESCRIPTION
This can happen due to `:key` being equal to the same cluster_number between different categories.

E.g: In world news an article has cluster_number 2, and when I switch to europe and click on an article that has cluster_number 2 also, then Alpine doesn't understand that there was a change, due to the key being similar.

https://alpinejs.dev/directives/for#keys