### PR TITLE
add El Salto to the Spain category feeds

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1147,7 +1147,8 @@
       "https://www.lagacetadesalamanca.es/rss/2.0/portada/",
       "https://www.diariodecastillayleon.es/rss/home.xml",
       "https://www.diariodecastillayleon.es/rss/castilla-y-leon.xml",
-      "https://www.elnortedecastilla.es/rss/2.0/portada/"
+      "https://www.elnortedecastilla.es/rss/2.0/portada/",
+      "https://www.elsaltodiario.com/general/feed"
     ]
   },
   "Ireland": {

--- a/media_data.json
+++ b/media_data.json
@@ -2706,5 +2706,13 @@
     "description": "Omroep Brabant is the regional public broadcaster of the province of North Brabant that provides radio, television, and online news.",
     "owner": "Omroep Brabant Organisatie",
     "typology": "State Funded Media"
+  },
+  {
+    "country": "Spain",
+    "organization": "El Salto",
+    "domains": ["elsaltodiario.com"],
+    "description": "El Salto is an independent, subscription funded newspaper founded in 2017. Its online version works as daily newspaper covering in Spanish local and international events, investigation and debates.",
+    "owner": "Independent",
+    "typology": "Private Media"
   }
 ]


### PR DESCRIPTION
[El Salto](https://www.elsaltodiario.com/) is an independent newspaper funded by its subscriptions.

It covers both local and international affairs in Spanish.

I think it is a great addition to the sources for news in Spain.

Thanks : )