### PR TITLE
Add category "Switzerland (DE)"

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1402,5 +1402,35 @@
       "https://rss.donga.com/total.xml",
       "https://www.mbn.co.kr/rss/"
     ]
+  },
+  "Switzerland (DE)": {
+      "feeds": [
+        "https://d-nsbc-p.admin.ch/NSBSubscriber/feeds/rss?lang=de&org-nr=201",
+        "https://d-nsbc-p.admin.ch/NSBSubscriber/feeds/rss?lang=de&org-nr=301",
+        "https://d-nsbc-p.admin.ch/NSBSubscriber/feeds/rss?lang=de&org-nr=401",
+        "https://d-nsbc-p.admin.ch/NSBSubscriber/feeds/rss?lang=de&org-nr=501",
+        "https://d-nsbc-p.admin.ch/NSBSubscriber/feeds/rss?lang=de&org-nr=601",
+        "https://d-nsbc-p.admin.ch/NSBSubscriber/feeds/rss?lang=de&org-nr=701",
+        "https://d-nsbc-p.admin.ch/NSBSubscriber/feeds/rss?lang=de&org-nr=801",
+        "https://gmx.ch/feeds/rss/magazine/schweiz/index.rss",
+        "https://onlinereports.ch/api/rss-feed",
+        "https://partner-feeds.beta.20min.ch/rss/20minuten/ostschweiz",
+        "https://partner-feeds.beta.20min.ch/rss/20minuten/schweiz",
+        "https://partner-feeds.beta.20min.ch/rss/20minuten/wirtschaft",
+        "https://partner-feeds.beta.20min.ch/rss/20minuten/zentralschweiz",
+        "https://partner-feeds.publishing.tamedia.ch/rss/derbund/schweiz",
+        "https://partner-feeds.publishing.tamedia.ch/rss/tagesanzeiger/schweiz",
+        "https://polizeiticker.ch/rss",
+        "https://www.api.news.apps.be.ch/api/atom/news?domain=https%3A%2F%2Fwww.be.ch%2Fde%2Fstart%2Fdienstleistungen%2Fmedien%2Fmedienmitteilungen.html&lang=de&ouTagId=be-oe%3Abe&amount=30&maxAgeInDays=124",
+        "https://www.bluewin.ch/de/feed.xml",
+        "https://www.cash.ch/feeds/latest/news",
+        "https://www.presseportal-schweiz.ch/rss.xml",
+        "https://www.sg.ch/_jcr_content/NewsPar.RssFeed.qualident__item0.rdf",
+        "https://www.srf.ch/kultur/bnf/rss/454",
+        "https://www.srf.ch/news/bnf/rss/1890",
+        "https://www.srf.ch/news/bnf/rss/1926",
+        "https://www.srf.ch/sport/bnf/rss/718",
+        "https://www.watson.ch/api/2.0/rss/index.xml?tag=Schweiz"
+      ]
   }
 }

--- a/media_data.json
+++ b/media_data.json
@@ -2866,5 +2866,101 @@
     "description": "Nationwide cable TV channel for news and general programming.",
     "owner": "Maekyung Media Group",
     "typology": "Private Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "SRG SSR",
+    "domains": ["srgssr.ch", "srf.ch", "rsi.ch", "rts.ch", "rtr.ch"],
+    "description": "SRG SSR is a public service broadcaster in Switzerland. It is built upon a federalist model specific to the country’s political organization.",
+    "owner": "Swiss Confederation",
+    "typology": "Public Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "Federal administration of Switzerland",
+    "domains": ["admin.ch"],
+    "description": "Website of the Federal Administration of the Swiss Confederation (including Federal Council and Departments)",
+    "owner": "Swiss Confederation",
+    "typology": "State Funded Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "GMX",
+    "domains": ["gmx.ch"],
+    "description": "OnlineReports.ch is an Internet news portal from Basel, which mainly publishes regional research, news and comments.",
+    "owner": "1&1 Mail & Media GmbH",
+    "typology": "Private Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "OnlineReports GmbH",
+    "domains": ["onlinereports.ch"],
+    "description": "OnlineReports.ch is an Internet news portal from Basel, which mainly publishes regional research, news and comments.",
+    "owner": "Jan Amsler, Alessandra Paone",
+    "typology": "Private Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "20 Minuten",
+    "domains": ["20min.ch"],
+    "description": "Free daily newspaper in Switzerland",
+    "owner": "Express-Zeitung AG",
+    "typology": "Private Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "Der Bund",
+    "domains": ["derbund.ch"],
+    "description": "German-language daily newspaper published in Bern",
+    "owner": "TX Group",
+    "typology": "Private Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "Tages-Anzeiger",
+    "domains": ["tagesanzeiger.ch"],
+    "description": "German-language national daily newspaper published in Zurich",
+    "owner": "TX Group",
+    "typology": "Private Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "Canton of Bern",
+    "domains": ["be.ch"],
+    "description": "Press releases and news from the Canton of Bern",
+    "owner": "Canton of Bern",
+    "typology": "State Funded Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "Canton of St.Gallen",
+    "domains": ["sg.ch"],
+    "description": "Press releases and news from the Canton of St.Gallen",
+    "owner": "Canton of St.Gallen",
+    "typology": "State Funded Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "blue News",
+    "domains": ["bluewin.ch"],
+    "description": "Bluewin is a Swiss internet service provider that offers email and a news platform",
+    "owner": "Entertainment Programm AG",
+    "typology": "Public Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "Cash",
+    "domains": ["cash.ch"],
+    "description": "cash is a Swiss financial portal providing comprehensive economic and financial information with real-time market data from the Swiss stock exchange.",
+    "owner": "Ringier AG",
+    "typology": "Private Media"
+  },
+  {
+    "country": "Switzerland",
+    "organization": "Watson",
+    "domains": ["watson.ch"],
+    "description": "Swiss German- and French-language online newspaper published by CH Media that targets mobile users",
+    "owner": "CH Regionalmedien AG",
+    "typology": "Private Media"
   }
 ]


### PR DESCRIPTION
This PR will add a new category "Switzerland (DE)". Switzerland has four official languages and this category focuses on German (hence: DE). Some of the feeds don't have daily news, but they are official news from the government and I thought it would be worth including them.

I was not sure how to handle news outlets that have a mix of public news and pay-walled news. I included one that seemed to have mostly public news. Unfortunately there are a lot of pay-walled news outlets in Switzerland, or they are low quality gossip-style.