### PR TITLE
Added ifun and Allsides

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1966,7 +1966,7 @@
       "fr": "USA | Virginie",
       "es": "EE. UU. | Virginia",
       "pt": "EUA | Virgínia",
-      "it": "USA | Virginia",https://www.allsides.com/taxonomy/term/37391/feed
+      "it": "USA | Virginia",
       "nl": "VS | Virginia",
       "zh": "美国 | 弗吉尼亚州",
       "ja": "アメリカ | バージニア州",


### PR DESCRIPTION
I have added Allsides Unbalanced News for US and Europe, I had a hard time finding a world section. Perhaps this can be moved in there as well? Potentially the AI needs to distinguish between country and world news on its own.

https://www.allsides.com/unbiased-balanced-news

https://ifun.de is a site known for Apple specific news, I propose adding it here.