### PR TITLE
Add ETNews feeds (South Korea)

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1471,7 +1471,9 @@
       "https://www.yonhapnewstv.co.kr/category/news/local/feed/",
       "https://www.yonhapnewstv.co.kr/category/news/politics/feed/",
       "https://www.yonhapnewstv.co.kr/category/news/society/feed/",
-      "https://www.yonhapnewstv.co.kr/category/news/sports/feed/"
+      "https://www.yonhapnewstv.co.kr/category/news/sports/feed/",
+      "https://rss.etnews.com/Section901.xml",
+      "https://rss.etnews.com/Section902.xml"
     ]
   },
   "Spain": {


### PR DESCRIPTION
ETNews is a Korean tech news media, also sometimes quoted by English media.
e.g. https://kagi.com/search?q=ETNews+site%3Amacrumors.com

They don't only cover tech stories though; they also publish some articles on Korean politics.
The feed URL source is here: https://www.etnews.com/rss/

I've only added the 'Today's Stories' (Section901) and 'Breaking News' (Section902) for now.
(the latter, however, is actually more like 'recently posted articles')