### PR TITLE
feat: add toggle all button to sections settings

### DIFF
--- a/src/lib/components/settings/SettingsSections.svelte
+++ b/src/lib/components/settings/SettingsSections.svelte
@@ -56,9 +56,18 @@
 		<h4 class="mb-2 text-sm font-medium text-gray-700 dark:text-gray-300">
 			{s('settings.sections.title') || 'Article Sections'}
 		</h4>
-		<p class="mb-3 text-xs text-gray-500 dark:text-gray-400">
-			{s('settings.sections.instructions') || 'Drag to reorder sections. Toggle to enable/disable.'}
-		</p>
+		<div class="mb-3 flex justify-between items-center">
+			<p class="text-xs text-gray-500 dark:text-gray-400">
+				{s('settings.sections.instructions') || 'Drag to reorder sections. Toggle to enable/disable.'}
+			</p>
+
+			<button
+				class="text-sm text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300 mr-2"
+				onclick={() => sectionItems.map(section => sections.toggleSection(section.id))}
+			>
+				{s('settings.sections.toggleAll') || 'Toggle All'}
+			</button>
+		</div>
 
 		<div
 			class="space-y-2"

--- a/src/lib/locales/de.json
+++ b/src/lib/locales/de.json
@@ -1019,6 +1019,10 @@
         "text": "Artikelabschnitte",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "Alle umschalten",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "Schauen Sie sich Kite News auf {{language}} an - es wird die Einleitung überspringen und direkt in Ihrer Sprache laden!",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -1015,6 +1015,10 @@
         "text": "Article Sections",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "Toggle All",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "Check out Kite News in {language} - it will skip the intro and load directly in your language!",
         "translationContext": "Message to share with others, {language} will be replaced with the language name"

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -1019,6 +1019,10 @@
         "text": "Secciones del artículo",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "Alternar todo",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "¡Mira Kite News en {{language}} - omitirá la introducción y cargará directamente en tu idioma!",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -1019,6 +1019,10 @@
         "text": "Sections d'article",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "Tout basculer",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "Découvrez Kite News en français – l'intro sera ignorée et le contenu se chargera directement dans votre langue !",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/hi.json
+++ b/src/lib/locales/hi.json
@@ -1011,6 +1011,10 @@
         "text": "अनुच्छेद अनुभाग",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "सभी टॉगल करें",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "{{language}} में काइट न्यूज़ देखें - यह परिचय को छोड़ देगा और सीधे आपकी भाषा में लोड होगा!",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -1011,6 +1011,10 @@
         "text": "Sezioni Articolo",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "Attiva/disattiva tutto",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "Dai un'occhiata a Kite News in italiano: salterà l'introduzione e si caricherà direttamente nella tua lingua!",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/ja.json
+++ b/src/lib/locales/ja.json
@@ -1011,6 +1011,10 @@
         "text": "記事セクション",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "すべて切り替え",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "{{language}}でKite Newsをチェックしてください - イントロをスキップして、直接あなたの言語で読み込まれます！",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -1011,6 +1011,10 @@
         "text": "Artikelsecties",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "Alles omschakelen",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "Bekijk Kite News in het Nederlands - de intro wordt overgeslagen en het wordt direct in jouw taal geladen!",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/pt.json
+++ b/src/lib/locales/pt.json
@@ -1011,6 +1011,10 @@
         "text": "Seções do Artigo",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "Alternar todos",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "Confira o Kite News em {{language}} - ele vai pular a introdução e carregar direto no seu idioma!",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/uk.json
+++ b/src/lib/locales/uk.json
@@ -1011,6 +1011,10 @@
         "text": "Розділи статті",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "Перемкнути всі",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "Перегляньте Kite News українською – воно пропустить вступ і завантажиться безпосередньо вашою мовою!",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/zh-Hans.json
+++ b/src/lib/locales/zh-Hans.json
@@ -1011,6 +1011,10 @@
         "text": "文章分区",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "全部切换",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.shareLanguage.message": {
         "text": "请查看中文版《风筝新闻》——它将跳过介绍，直接以您的语言加载！",
         "translationContext": "Message to share with others, {{language}} will be replaced with the language name"

--- a/src/lib/locales/zh-Hant.json
+++ b/src/lib/locales/zh-Hant.json
@@ -571,6 +571,10 @@
         "text": "文章區塊設定",
         "translationContext": "Title for the article sections settings"
     },
+    "settings.sections.toggleAll": {
+        "text": "全部切換",
+        "translationContext": "Button text to toggle all sections on/off at once"
+    },
     "settings.sections.instructions": {
         "text": "拖曳以重新排序區段。使用開關啟用/停用。",
         "translationContext": "Instructions for managing article sections"


### PR DESCRIPTION


Added a "Toggle All" button in the sections settings panel that allows users to quickly enable or disable all article sections at once.

![chrome-capture-2025-07-26](https://github.com/user-attachments/assets/7bb3bb94-2bdf-4cf4-ab46-10aa8fbacdc3)