### PR TITLE
feat: add auto-expand all stories functionality

### DIFF
--- a/src/lib/components/CategoryNavigation.svelte
+++ b/src/lib/components/CategoryNavigation.svelte
@@ -2,6 +2,7 @@
 import { s } from '$lib/client/localization.svelte';
 import { toCamelCase } from '$lib/utils/string.js';
 import { fontSize } from '$lib/stores/fontSize.svelte.js';
+import { settings } from '$lib/stores/settings.svelte.js';
 import type { Category } from '$lib/types';
 import { onMount } from 'svelte';
 import { browser } from '$app/environment';
@@ -13,6 +14,7 @@ interface Props {
 	categories?: Category[];
 	currentCategory?: string;
 	onCategoryChange?: (category: string) => void;
+	onCategoryDoubleClick?: (category: string) => void;
 	mobilePosition?: 'top' | 'bottom';
 	temporaryCategory?: string | null;
 	showTemporaryTooltip?: boolean;
@@ -21,7 +23,8 @@ interface Props {
 let { 
 	categories = [], 
 	currentCategory = 'World', 
-	onCategoryChange, 
+	onCategoryChange,
+	onCategoryDoubleClick,
 	mobilePosition = 'bottom',
 	temporaryCategory = null,
 	showTemporaryTooltip = false
@@ -182,6 +185,7 @@ $effect(() => {
 						class:dark:hover:text-gray-200={currentCategory !== category.id}
 						onclick={() => handleCategoryClick(category.id)}
 						onkeydown={(e) => handleCategoryKeydown(e, category.id)}
+						ondblclick={() => settings.storyExpandMode !== 'never' && onCategoryDoubleClick?.(category.id)}
 					>
 						{getCategoryDisplayName(category)}
 					</button>

--- a/src/lib/components/settings/SettingsGeneral.svelte
+++ b/src/lib/components/settings/SettingsGeneral.svelte
@@ -6,6 +6,7 @@ import { dataLanguage } from '$lib/stores/dataLanguage.svelte.js';
 import { fontSize, type FontSize } from '$lib/stores/fontSize.svelte.js';
 import { storyCount } from '$lib/stores/storyCount.svelte.js';
 import { settings } from '$lib/stores/settings.svelte.js';
+import type { StoryExpandMode } from '$lib/stores/settings.svelte.js';
 import { SUPPORTED_LANGUAGES } from '$lib/constants/languages.js';
 import { dataReloadService } from '$lib/services/dataService.js';
 import Select from '$lib/components/Select.svelte';
@@ -57,8 +58,16 @@ let currentLanguage = $state(language.current as string);
 let currentDataLanguage = $state(dataLanguage.current as string);
 let currentFontSize = $state(fontSize.current as string);
 let currentCategoryHeaderPosition = $state(settings.categoryHeaderPosition as string);
+let currentStoryExpandMode = $state(settings.storyExpandMode as string);
 let isLanguageLoading = $state(false);
 let isDataLanguageLoading = $state(false);
+
+// Story expand mode options for display
+const storyExpandModeOptions = $derived([
+	{ value: 'always', label: s('settings.storyExpandMode.always') || 'Always expand all' },
+	{ value: 'doubleClick', label: s('settings.storyExpandMode.doubleClick') || 'Double-click to expand all' },
+	{ value: 'never', label: s('settings.storyExpandMode.never') || 'Never expand all' }
+]);
 
 // Sync local state with stores
 $effect(() => {
@@ -79,6 +88,10 @@ $effect(() => {
 
 $effect(() => {
 	currentCategoryHeaderPosition = settings.categoryHeaderPosition as string;
+});
+
+$effect(() => {
+	currentStoryExpandMode = settings.storyExpandMode as string;
 });
 
 // Theme change handler
@@ -130,6 +143,11 @@ function handleStoryCountChange(count: number) {
 function handleCategoryHeaderPositionChange(position: string) {
 	settings.setCategoryHeaderPosition(position as any);
 	currentCategoryHeaderPosition = position;
+}
+
+function handleStoryExpandModeChange(mode: StoryExpandMode) {
+	settings.setStoryExpandMode(mode);
+	currentStoryExpandMode = mode;
 }
 
 // Show about screen
@@ -241,6 +259,19 @@ function showAbout() {
 			label={s('settings.fontSize.label') || 'Text Size'}
 			onChange={handleFontSizeChange}
 		/>
+	</div>
+
+	<!-- Story Expand Mode Setting -->
+	<div class="flex flex-col space-y-2">
+			   <Select
+					   bind:value={currentStoryExpandMode}
+					   options={storyExpandModeOptions}
+					   label={s('settings.storyExpandMode.label') || 'Story Expand Mode'}
+					   onChange={handleStoryExpandModeChange}
+			   />
+		<p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+			{s('settings.storyExpandMode.description') || 'Choose how stories expand in a category'}
+		</p>
 	</div>
 
 	<!-- Story Count Setting -->

--- a/src/lib/components/story/StoryCard.svelte
+++ b/src/lib/components/story/StoryCard.svelte
@@ -24,6 +24,7 @@ interface Props {
 	priority?: boolean; // For high-priority stories (first few visible)
 	isFiltered?: boolean;
 	filterKeywords?: string[];
+	shouldAutoScroll?: boolean;
 }
 
 let { 
@@ -32,7 +33,8 @@ let {
 	batchId,
 	categoryId,
 	isRead = false, 
-	isExpanded = false, 
+	isExpanded = false,
+	shouldAutoScroll = false, 
 	onToggle, 
 	onReadToggle, 
 	showSourceOverlay = $bindable(false),
@@ -89,11 +91,9 @@ function handleReadClick(e: Event) {
 	if (onReadToggle) onReadToggle();
 }
 
-
-
 // Scroll to story when expanded
 $effect(() => {
-	if (isExpanded && browser && storyElement) {
+	if (isExpanded && browser && storyElement && shouldAutoScroll) {
 		// Small delay to ensure the content is rendered
 		setTimeout(() => {
 			// Calculate dynamic header height and offsets

--- a/src/lib/locales/de.json
+++ b/src/lib/locales/de.json
@@ -1035,6 +1035,26 @@
         "text": "Anzahl der angezeigten Artikel:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "Wählen Sie, wie Artikel beim Betrachten einer Kategorie erweitert werden",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "Artikel-Erweiterungsmodus",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "Alle immer erweitern",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "Doppelklick zum Erweitern aller",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "Niemals alle erweitern",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "Kategorien",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -1031,6 +1031,26 @@
         "text": "Number of stories shown:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "Choose how stories expand when viewing a category",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "Story Expand Mode",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "Always expand all",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "Double-click to expand all",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "Never expand all",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "Categories",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -1035,6 +1035,26 @@
         "text": "Número de historias mostradas:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "Elige cómo se expanden las historias al ver una categoría",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "Modo de expansión de historias",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "Expandir siempre todas",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "Doble clic para expandir todas",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "Nunca expandir todas",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "Categorías",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -1035,6 +1035,26 @@
         "text": "Nombre d'histoires affichées :",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "Choisissez comment les articles se développent lors de la visualisation d'une catégorie",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "Mode d'expansion des articles",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "Toujours tout développer",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "Double-clic pour tout développer",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "Ne jamais tout développer",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "Catégories",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/hi.json
+++ b/src/lib/locales/hi.json
@@ -1027,6 +1027,26 @@
         "text": "प्रदर्शित कहानियों की संख्या:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "चुनें कि कैटेगरी देखते समय कहानियां कैसे विस्तृत होती हैं",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "कहानी विस्तार मोड",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "हमेशा सभी को विस्तृत करें",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "सभी को विस्तृत करने के लिए डबल-क्लिक करें",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "कभी भी सभी को विस्तृत न करें",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "श्रेणियाँ",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -1027,6 +1027,26 @@
         "text": "Numero di storie mostrate:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "Scegli come si espandono le storie quando visualizzi una categoria",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "Modalità espansione storie",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "Espandi sempre tutte",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "Doppio clic per espandere tutte",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "Non espandere mai tutte",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "Categorie",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/ja.json
+++ b/src/lib/locales/ja.json
@@ -1027,6 +1027,26 @@
         "text": "表示するストーリー数:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "カテゴリを表示する際のストーリーの展開方法を選択してください",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "ストーリー展開モード",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "常にすべて展開",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "ダブルクリックですべて展開",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "すべて展開しない",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "カテゴリー",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -1027,6 +1027,26 @@
         "text": "Aantal getoonde verhalen:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "Kies hoe verhalen uitvouwen bij het bekijken van een categorie",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "Verhaal uitvouwmodus",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "Altijd alles uitvouwen",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "Dubbelklik om alles uit te vouwen",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "Nooit alles uitvouwen",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "Categorieën",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/pt.json
+++ b/src/lib/locales/pt.json
@@ -1027,6 +1027,26 @@
         "text": "Número de histórias exibidas:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "Escolha como as histórias se expandem ao visualizar uma categoria",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "Modo de expansão de histórias",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "Sempre expandir todas",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "Duplo clique para expandir todas",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "Nunca expandir todas",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "Categorias",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/uk.json
+++ b/src/lib/locales/uk.json
@@ -1027,6 +1027,26 @@
         "text": "Кількість показаних історій:",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "Виберіть, як історії розгортаються при перегляді категорії",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "Режим розгортання історій",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "Завжди розгортати всі",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "Подвійний клік для розгортання всіх",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "Ніколи не розгортати всі",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "Категорії",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/zh-Hans.json
+++ b/src/lib/locales/zh-Hans.json
@@ -1027,6 +1027,26 @@
         "text": "显示的故事数量：",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "选择查看类别时故事的展开方式",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "故事展开模式",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "始终展开全部",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "双击展开全部",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "从不展开全部",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.tabs.categories": {
         "text": "分类",
         "translationContext": "Title for the categories settings tab"

--- a/src/lib/locales/zh-Hant.json
+++ b/src/lib/locales/zh-Hant.json
@@ -495,6 +495,26 @@
         "text": "顯示故事數量：",
         "translationContext": "Label for the story count setting"
     },
+    "settings.storyExpandMode.description": {
+      "text": "選擇檢視類別時故事的展開方式",
+      "translationContext": "Description for story expand mode setting"
+    },
+    "settings.storyExpandMode.label": {
+      "text": "故事展開模式",
+      "translationContext": "Label for story expand mode setting"
+    },
+    "settings.storyExpandMode.always": {
+      "text": "始終展開全部",
+      "translationContext": "Option to always expand all stories automatically"
+    },
+    "settings.storyExpandMode.doubleClick": {
+      "text": "雙擊展開全部",
+      "translationContext": "Option to expand all stories via double-click on category"
+    },
+    "settings.storyExpandMode.never": {
+      "text": "從不展開全部",
+      "translationContext": "Option to disable bulk story expansion"
+    },
     "settings.aboutKite.button": {
         "text": "關於 Kite",
         "translationContext": "Text for the About Kite button"

--- a/src/lib/stores/settings.svelte.ts
+++ b/src/lib/stores/settings.svelte.ts
@@ -2,6 +2,7 @@ import { browser } from "$app/environment";
 
 export type FontSize = "small" | "normal" | "large";
 export type CategoryHeaderPosition = "top" | "bottom";
+export type StoryExpandMode = "always" | "doubleClick" | "never";
 
 interface SettingsState {
   isOpen: boolean;
@@ -10,6 +11,7 @@ interface SettingsState {
   categoryHeaderPosition: CategoryHeaderPosition;
   showIntro: boolean;
   activeTab?: string;
+  storyExpandMode: StoryExpandMode;
 }
 
 // Initialize settings state
@@ -19,6 +21,7 @@ const settingsState = $state<SettingsState>({
   storyCount: 10,
   categoryHeaderPosition: "bottom",
   showIntro: false,
+  storyExpandMode: "doubleClick",
 });
 
 // Helper functions
@@ -76,6 +79,15 @@ export const settings = {
     return settingsState.activeTab;
   },
 
+  get storyExpandMode() {
+    return settingsState.storyExpandMode;
+  },
+
+  setStoryExpandMode(mode: StoryExpandMode) {
+    settingsState.storyExpandMode = mode;
+    saveToStorage("storyExpandMode", mode);
+  },
+
   open(tab?: string) {
     settingsState.isOpen = true;
     if (tab) {
@@ -131,6 +143,7 @@ export const settings = {
     settingsState.storyCount = Math.max(3, Math.min(12, storyCount));
     settingsState.categoryHeaderPosition = categoryHeaderPosition;
     settingsState.showIntro = !introShown;
+    settingsState.storyExpandMode = loadFromStorage("storyExpandMode", "doubleClick") as StoryExpandMode;
 
     applyFontSize(fontSize);
   },


### PR DESCRIPTION
As a user, I often want to quickly read through multiple stories without clicking each one individually. However, I assume some people just want a quick overview. So I'm adding a configurable way to expand all.

There are 3 modes (selected in settings):
- Always auto-expand
- Double-click on the category to expand all (this is the new default)
- Never auto-expand, double-click is disabled (current behavior)

Note that the stories are not marked as read if they are auto-expanded.

I tested it on desktop:

![Recording 2025-08-02 012642](https://github.com/user-attachments/assets/b7d89d9c-a3f0-4025-b07f-e59554133d35)