### PR TITLE
feat: add missing category locales

### DIFF
--- a/src/lib/locales/de.json
+++ b/src/lib/locales/de.json
@@ -351,6 +351,38 @@
         "text": "Welt",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "Bitcoin",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "China",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "Taiwan",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "Kolumbien",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "Tschechien",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "Finnland",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "Palästina",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "Russland",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "Diese Information ist allgemein bekannt und stammt nicht aus einer bestimmten Nachrichtenquelle, wird jedoch für den Kontext und die Vollständigkeit der Geschichte aufgenommen.",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/en.json
+++ b/src/lib/locales/en.json
@@ -347,6 +347,38 @@
         "text": "World",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "Bitcoin",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "China",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "Taiwan",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "Colombia",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "Czech Republic",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "Finland",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "Palestine",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "Russia",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "This information is common knowledge not pulled from a specific news source, but is included for context and completeness of the story.",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/es.json
+++ b/src/lib/locales/es.json
@@ -351,6 +351,38 @@
         "text": "Mundo",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "Bitcoin",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "China",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "Taiwán",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "Colombia",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "República Checa",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "Finlandia",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "Palestina",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "Rusia",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "Esta información es conocimiento general, no proviene de una fuente de noticias específica, pero se incluye para proporcionar contexto y completar la historia.",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/fr.json
+++ b/src/lib/locales/fr.json
@@ -351,6 +351,38 @@
         "text": "Monde",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "Bitcoin",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "Chine",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "Taïwan",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "Colombie",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "République tchèque",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "Finlande",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "Palestine",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "Russie",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "Ces informations relèvent du savoir commun et ne proviennent pas d'une source d'information spécifique, mais sont incluses pour le contexte et l'exhaustivité de l'histoire.",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/hi.json
+++ b/src/lib/locales/hi.json
@@ -351,6 +351,38 @@
         "text": "विश्व",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "बिटकॉइन",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "चीन",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "ताइवान",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "कोलंबिया",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "चेक गणराज्य",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "फिनलैंड",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "फिलिस्तीन",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "रूस",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "यह जानकारी सामान्य ज्ञान है जो किसी विशिष्ट समाचार स्रोत से नहीं ली गई है, लेकिन कहानी के संदर्भ और पूर्णता के लिए शामिल की गई है।",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/it.json
+++ b/src/lib/locales/it.json
@@ -351,6 +351,38 @@
         "text": "Mondo",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "Bitcoin",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "Cina",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "Taiwan",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "Colombia",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "Repubblica Ceca",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "Finlandia",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "Palestina",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "Russia",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "Queste informazioni sono di dominio pubblico e non provengono da una fonte di notizie specifica, ma sono incluse per fornire contesto e completezza alla storia.",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/ja.json
+++ b/src/lib/locales/ja.json
@@ -351,6 +351,38 @@
         "text": "世界",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "ビットコイン",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "中国",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "台湾",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "コロンビア",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "チェコ共和国",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "フィンランド",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "パレスチナ",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "ロシア",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "この情報は特定のニュースソースから引用したものではなく、一般的な知識として知られている内容です。物語の文脈と完全性を補うために記載されています。",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/nl.json
+++ b/src/lib/locales/nl.json
@@ -351,6 +351,38 @@
         "text": "Wereld",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "Bitcoin",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "China",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "Taiwan",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "Colombia",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "Tsjechië",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "Finland",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "Palestina",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "Rusland",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "Deze informatie is algemene kennis, niet afkomstig van een specifieke nieuwsbron, maar is opgenomen ter context en volledigheid van het verhaal.",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/pt.json
+++ b/src/lib/locales/pt.json
@@ -351,6 +351,38 @@
         "text": "Mundo",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "Bitcoin",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "China",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "Taiwan",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "Colômbia",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "República Tcheca",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "Finlândia",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "Palestina",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "Rússia",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "Esta informação é de conhecimento geral, não retirada de uma fonte de notícias específica, mas incluída para dar contexto e completar a história.",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/uk.json
+++ b/src/lib/locales/uk.json
@@ -351,6 +351,38 @@
         "text": "Світ",
         "translationContext": "Display name for the World news category"
     },
+    "category.bitcoin": {
+        "text": "Біткоїн",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "Китай",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.chinaTaiwan": {
+        "text": "Тайвань",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.colombia": {
+        "text": "Колумбія",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "Чехія",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "Фінляндія",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "Палестина",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "Росія",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "Ця інформація є загальновідомою, не взята з конкретного джерела новин, але включена для контексту та повноти розповіді.",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/zh-Hans.json
+++ b/src/lib/locales/zh-Hans.json
@@ -351,6 +351,38 @@
         "text": "世界",
         "translationContext": "Display name for the World news category"
     },
+    "category.chinaTaiwan": {
+        "text": "台湾",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.bitcoin": {
+        "text": "比特币",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "中国",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.colombia": {
+        "text": "哥伦比亚",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "捷克共和国",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "芬兰",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "巴勒斯坦",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "俄罗斯",
+        "translationContext": "Display name for the Russia news category"
+    },
     "citation.commonKnowledge.description": {
         "text": "此信息为常识，并非来自特定新闻来源，但出于背景和故事完整性的考虑而纳入。",
         "translationContext": "Description explaining what common knowledge citations are"

--- a/src/lib/locales/zh-Hant.json
+++ b/src/lib/locales/zh-Hant.json
@@ -107,6 +107,90 @@
         "text": "國際",
         "translationContext": "Display name for the World news category"
     },
+    "category.chinaTaiwan": {
+        "text": "台灣",
+        "translationContext": "Display name for the Taiwan news category"
+    },
+    "category.bitcoin": {
+        "text": "比特幣",
+        "translationContext": "Display name for the Bitcoin news category"
+    },
+    "category.china": {
+        "text": "中國",
+        "translationContext": "Display name for the China news category"
+    },
+    "category.ai": {
+        "text": "人工智慧",
+        "translationContext": "Display name for the AI news category"
+    },
+    "category.apple": {
+        "text": "蘋果",
+        "translationContext": "Display name for the Apple news category"
+    },
+    "category.costaRica": {
+        "text": "哥斯大黎加",
+        "translationContext": "Display name for the Costa Rica news category"
+    },
+    "category.cybersecurity": {
+        "text": "網路安全",
+        "translationContext": "Display name for the Cybersecurity news category"
+    },
+    "category.economy": {
+        "text": "經濟",
+        "translationContext": "Display name for the Economy news category"
+    },
+    "category.india": {
+        "text": "印度",
+        "translationContext": "Display name for the India news category"
+    },
+    "category.pakistan": {
+        "text": "巴基斯坦",
+        "translationContext": "Display name for the Pakistan news category"
+    },
+    "category.southKorea": {
+        "text": "南韓",
+        "translationContext": "Display name for the South Korea news category"
+    },
+    "category.sweden": {
+        "text": "瑞典",
+        "translationContext": "Display name for the Sweden news category"
+    },
+    "category.switzerlandDe": {
+        "text": "瑞士（德語）",
+        "translationContext": "Display name for the Switzerland (DE) news category"
+    },
+    "category.theNetherlands": {
+        "text": "荷蘭",
+        "translationContext": "Display name for The Netherlands news category"
+    },
+    "category.usaVermont": {
+        "text": "美國 | 佛蒙特州",
+        "translationContext": "Display name for the USA Vermont regional news category"
+    },
+    "category.usaVirginia": {
+        "text": "美國 | 維吉尼亞州",
+        "translationContext": "Display name for the USA Virginia regional news category"
+    },
+    "category.colombia": {
+        "text": "哥倫比亞",
+        "translationContext": "Display name for the Colombia news category"
+    },
+    "category.czechRepublic": {
+        "text": "捷克共和國",
+        "translationContext": "Display name for the Czech Republic news category"
+    },
+    "category.finland": {
+        "text": "芬蘭",
+        "translationContext": "Display name for the Finland news category"
+    },
+    "category.palestine": {
+        "text": "巴勒斯坦",
+        "translationContext": "Display name for the Palestine news category"
+    },
+    "category.russia": {
+        "text": "俄羅斯",
+        "translationContext": "Display name for the Russia news category"
+    },
     "category.business": {
         "text": "商業",
         "translationContext": "Display name for the Business news category"
@@ -140,7 +224,7 @@
         "translationContext": "Display name for the USA news category"
     },
     "category.gaming": {
-        "text": "遊戲新聞",
+        "text": "遊戲",
         "translationContext": "Display name for the Gaming news category"
     },
     "category.bayArea": {
@@ -152,7 +236,7 @@
         "translationContext": "Display name for the Cryptocurrency news category"
     },
     "category.europe": {
-        "text": "歐洲新聞",
+        "text": "歐洲",
         "translationContext": "Display name for the Europe news category"
     },
     "category.uk": {
@@ -212,7 +296,7 @@
         "translationContext": "Display name for the France news category"
     },
     "category.poland": {
-        "text": "波蘭新聞",
+        "text": "波蘭",
         "translationContext": "Display name for the Poland news category"
     },
     "category.slovenia": {


### PR DESCRIPTION
- Add missing category locales in all languages
- FIx few locales in zh-Hant

@giorgiobrullo I noticed you changed the category name from "Taiwan" to "China | Taiwan".
I respect your decision, though personally I prefer keeping it simply as "Taiwan" in the translations.
Feel free to adjust them as you see fit.