### PR TITLE
[content filter]: for sexual misconduct

### DIFF
--- a/contentFilters.json
+++ b/contentFilters.json
@@ -199,6 +199,26 @@
         "ru": ["изменение климата", "глобальное потепление", "выбросы углерода", "парниковые газы", "климатический кризис", "экстремальная погода", "повышение уровня моря", "вымирание", "климатическая чрезвычайная ситуация"],
         "uk": ["зміна клімату", "глобальне потепління", "викиди вуглецю", "парникові гази", "кліматична криза", "екстремальна погода", "підвищення рівня моря", "вимирання", "кліматична надзвичайна ситуація"]
       }
+    },
+    {
+      "id": "sexual-misconduct",
+      "label": "Sexual Misconduct",
+      "keywords": {
+        "default": ["sexual assault", "sexual harassment", "rape", "sexual abuse", "metoo", "groping", "molestation", "revenge porn", "pedophile"],
+        "en": ["sexual assault", "sexual harassment", "rape", "sexual abuse", "metoo", "groping", "molestation", "revenge porn", "pedophile"],
+        "pt": ["agressão sexual", "assédio sexual", "estupro", "abuso sexual", "metoo", "aperto/encoxação", "molestação", "pornografia de vingança", "pedófilo"],
+        "it": ["violenza sessuale", "molestie sessuali", "stupro", "abuso sessuale", "metoo", "palpeggiamento", "molestia", "revenge porn", "pedofilo"],
+        "fr": ["agression sexuelle", "harcèlement sexuel", "viol", "abus sexuel", "metoo", "attouchements", "molestation", "porno vengeance", "pédophile"],
+        "es": ["agresión sexual", "acoso sexual", "violación", "abuso sexual", "metoo", "manoseo", "abusos", "porno de venganza", "pedófilo"],
+        "de": ["sexueller Übergriff", "sexuelle Belästigung", "Vergewaltigung", "sexueller Missbrauch", "metoo", "Grapschen", "Belästigung", "Racheporno", "Pädophiler"],
+        "nl": ["verkrachting", "seksuele intimidatie", "verkrachting", "seksueel misbruik", "metoo", "aanranding", "seksueel geweld", "wraakporno", "pedofiel"],
+        "zh-Hans": ["性侵犯", "性骚扰", "强奸", "性虐待", "我也是", "猥亵", "骚扰", "复仇色情", "恋童癖者"],
+        "zh-Hant": ["性侵犯", "性騷擾", "強姦", "性虐待", "metoo", "猥褻", "性騷擾", "復仇式色情", "戀童癖"],
+        "ja": ["性的暴行", "セクハラ", "レイプ", "性的虐待", "metoo", "痴漢", "わいせつ行為", "リベンジポルノ", "小児性愛者"],
+        "hi": ["यौन उत्पीड़न", "यौन उत्पीड़न", "बलात्कार", "यौन शोषण", "मीटू", "छेड़छाड़", "बाल यौन शोषण", "रिवेंज पोर्न", "बाल यौन शोषण"],
+        "ru": ["сексуальное насилие", "сексуальное домогательство", "изнасилование", "сексуальное надругательство", "metoo", "лапать", "растление", "порноместь", "педофил"],
+        "uk": ["сексуальное насилие", "сексуальное домогательство", "изнасилование", "сексуальное надругательство", "metoo", "лапать", "растление", "порноместь", "педофил"]
+      }
     }
   ]
 }


### PR DESCRIPTION
It's fairly common to not want to see news about sexual violence so I've added a filter for it; some things to consider:

1. Does multiple variations of the word need to be included? for example `grope`/`groping`, `molest`/`molestation`, etc
2. Of course this list is not exhaustive but picked from my personal block list
3. I cannot be sure of the accuracy of the translations. They are, however, all from kagi translate.

I also see that this is a simple file for edits and the actual file adding this to a the default view is in the [data](https://github.com/kagisearch/kite-public/blob/main/src/lib/data/contentFilters.json) folder, needs a [tooltip to be added](https://github.com/kagisearch/kite-public/blob/main/src/lib/locales/en.json), etc. If this category is accepted I'm happy to do the work to take this to completion. 

small nit: This filter would be the eleventh one, so it would be good to add a twelfth filter to keep the visual neatness. 
<img width="788" height="629" alt="Screenshot 2025-10-01 at 12 11 05 AM" src="https://github.com/user-attachments/assets/02eda61d-f596-4644-8d69-77d1e0f1938d" />
