### PR TITLE
Updating feeds for VG under Norway

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1374,9 +1374,9 @@
       "https://www.tv2.no/rss/nyheter/utenriks",
       "https://www.tv2.no/rss/sport",
       "https://www.tv2.no/rss/underholdning",
-      "https://www.vg.no/rss/feed/?categories=1069",
+      "https://www.vg.no/rss/feed/?categories=1068",
       "https://www.vg.no/rss/feed/?categories=1070",
-      "https://www.vg.no/rss/feed/forsiden/"
+      "https://www.vg.no/feed/rss"
     ]
   },
   "Pakistan": {


### PR DESCRIPTION
VG have updated their feeds (relatively) lately. Removed category 1069, which has no new entries since May.

Updated the non-working general rss feed which has the last 10 items to be posted on the main webpage.

Added categories 1068, which is limited to domestic news.

All feeds only have the latest 10 stories, which is not ideal, but better than nothing.

https://www.vg.no/rss/feed/?categories=1071 also works, and has opinion pieces/commentary relating to news. It may help to add context, and perhaps be data that can be useful in summarizing stories and adding context - but I'm not sure if a feed dedicated to commentary of news rather than the stories themselves is within the intentions of this project.