### PR TITLE
Replace Slate Star Codex with Astral Codex Ten

### DIFF
--- a/core_feeds.py
+++ b/core_feeds.py
@@ -832,7 +832,7 @@ feeds = {
         "http://rss.cnn.com/rss/cnn_allpolitics.rss",
         "http://rss.cnn.com/rss/edition_us.rss",
         "http://rss.slashdot.org/Slashdot/slashdotPolitics",
-        "http://slatestarcodex.com/feed/",
+        "https://www.astralcodexten.com/feed",
         "http://www.marketwatch.com/rss/topstories/",
         "http://www.metafilter.com/tags/us/rss",
         "http://www.metafilter.com/tags/uspolitics/rss",


### PR DESCRIPTION
Currently the US category includes Scott Alexander's Slate Star Codex feed, which doesn't publish new articles anymore. The category should include Astral Codex Ten instead.

```rss
<?xml version="1.0" encoding="UTF-8"?><rss version="2.0"
	xmlns:content="http://purl.org/rss/1.0/modules/content/"
	xmlns:wfw="http://wellformedweb.org/CommentAPI/"
	xmlns:dc="http://purl.org/dc/elements/1.1/"
	xmlns:atom="http://www.w3.org/2005/Atom"
	xmlns:sy="http://purl.org/rss/1.0/modules/syndication/"
	xmlns:slash="http://purl.org/rss/1.0/modules/slash/"
	
	xmlns:georss="http://www.georss.org/georss"
	xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
	>

<channel>
	<title>Slate Star Codex</title>
	<atom:link href="https://slatestarcodex.com/feed/" rel="self" type="application/rss+xml" />
	<link>https://slatestarcodex.com</link>
	<description></description>
	<lastBuildDate>Fri, 23 Apr 2021 16:46:47 +0000</lastBuildDate>
	<language>en-US</language>
	<sy:updatePeriod>
	hourly	</sy:updatePeriod>
	<sy:updateFrequency>
	1	</sy:updateFrequency>
	<generator>https://wordpress.org/?v=6.8.2</generator>
	<item>
		<title>Introducing Astral Codex Ten</title>
		<link>https://slatestarcodex.com/2021/01/21/introducing-astral-codex-ten/</link>
					<comments>https://slatestarcodex.com/2021/01/21/introducing-astral-codex-ten/#comments</comments>
		
		<dc:creator><![CDATA[Scott Alexander]]></dc:creator>
		<pubDate>Thu, 21 Jan 2021 23:55:03 +0000</pubDate>
				<category><![CDATA[Uncategorized]]></category>
		<guid isPermaLink="false">https://slatestarcodex.com/?p=6043</guid>

					<description><![CDATA[Thanks for bearing with me the past few months. My new blog is at https://astralcodexten.substack.com/. I&#8217;ll try to have a less unwieldy domain name working soon.]]></description>
										<content:encoded><![CDATA[<p>Thanks for bearing with me the past few months. My new blog is at <A HREF="https://astralcodexten.substack.com/">https://astralcodexten.substack.com/</A>. I&#8217;ll try to have a less unwieldy domain name working soon.</p>
]]></content:encoded>
					
					<wfw:commentRss>https://slatestarcodex.com/2021/01/21/introducing-astral-codex-ten/feed/</wfw:commentRss>
			<slash:comments>10</slash:comments>
		
		
			</item>
	</channel>
</rss>
```