### PR TITLE
Preserve order when disabling categories

### DIFF
--- a/src/lib/data/settings.svelte.ts
+++ b/src/lib/data/settings.svelte.ts
@@ -428,9 +428,13 @@ export const categorySettings = $state({
 	setDisabled(newDisabled: string[]) {
 		categoriesState.disabled = newDisabled;
 		settings.disabledCategories.currentValue = newDisabled;
-		// Update enabled to be all categories not in disabled
+		// Update enabled to be all categories not in disabled while maintaining order
 		const allCategoryIds = categoriesState.allCategories.map((cat) => cat.id);
-		categoriesState.enabled = allCategoryIds.filter((cat) => !newDisabled.includes(cat));
+		const newEnabled = categoriesState.enabled.filter((cat) => !newDisabled.includes(cat))
+		// Add all categories not found in disabled or newEnabled
+		categoriesState.enabled = newEnabled.concat(
+		  allCategoryIds.filter((cat) => !newDisabled.includes(cat) && !newEnabled.includes(cat))
+		)
 		settings.enabledCategories.currentValue = categoriesState.enabled;
 		settings.enabledCategories.save();
 		settings.disabledCategories.save();


### PR DESCRIPTION
This pull request aims to resolve issue #207 where disabling a category does not maintain the enabled category order.

My solution involves filtering newly disabled categories from the previously enabled categories and then appending all categories which are not currently found in the disabled categories list.

While writing this solution I wanted to maintain the old behavior where all categories not found in the disabled list are added to the enabled list. Is there a reason this needs to be done instead of simply filtering out the newly disabled category from the enabled list? I assume that it is done to ensure that newly implemented categories which have not been populated in the enabled/disabled category lists will always end up getting added to one of the lists. Would it perhaps be better to perform this sort of operation elsewhere, perhaps when loading the categories settings page? 