### PR TITLE
Add newly implemented categories to disabled instead of enabled

### DIFF
--- a/src/lib/data/settings.svelte.ts
+++ b/src/lib/data/settings.svelte.ts
@@ -426,16 +426,14 @@ export const categorySettings = $state({
 		);
 	},
 	setDisabled(newDisabled: string[]) {
-		categoriesState.disabled = newDisabled;
-		settings.disabledCategories.currentValue = newDisabled;
-		// Update enabled to be all categories not in disabled while maintaining order
+		// Remove disabled categories from enabled
+		categoriesState.enabled = categoriesState.enabled.filter((cat) => !newDisabled.includes(cat));
+		// Disable all categories not found in enabled
 		const allCategoryIds = categoriesState.allCategories.map((cat) => cat.id);
-		const newEnabled = categoriesState.enabled.filter((cat) => !newDisabled.includes(cat))
-		// Add all categories not found in disabled or newEnabled
-		categoriesState.enabled = newEnabled.concat(
-		  allCategoryIds.filter((cat) => !newDisabled.includes(cat) && !newEnabled.includes(cat))
-		)
+		categoriesState.disabled = allCategoryIds.filter((cat) => !categoriesState.enabled.includes(cat));
+
 		settings.enabledCategories.currentValue = categoriesState.enabled;
+		settings.disabledCategories.currentValue = categoriesState.disabled;
 		settings.enabledCategories.save();
 		settings.disabledCategories.save();
 	},


### PR DESCRIPTION
After my previous PR (#208) I was doing some unrelated testing and noticed some undesirable behavior. When new categories are implemented, but have not yet been populated in either the enabled or disabled category lists, they are automatically placed in the enabled list. This seems undesirable since it means that every new category gets automatically enabled, quickly cluttering the enabled category list with items that the user probably doesn't want.

This PR changes the behavior so that the newly added categories get added to the disabled list instead of being automatically enabled (this is how `setEnabled` already works).

If I have time this weekend, I'm going to look into moving the newly-implemented-category logic out of `setEnabled` and `setDisabled` as mentioned at the bottom of #208.