### PR TITLE
Add more sources for Austria

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -108,7 +108,10 @@
       "https://www.fma.gv.at/category/news/feed/",
       "https://www.moment.at/feed",
       "https://www.selektiv.at/feed/",
-      "https://www.wienerzeitung.at/rss.xml"
+      "https://www.wienerzeitung.at/rss.xml",
+      "https://www.falter.at/rss",
+      "https://www.kleinezeitung.at/rss/oesterreich",
+      "https://www.nachrichten.at/storage/rss/rss/nachrichten.xml"
     ]
   },
   "Belgium": {


### PR DESCRIPTION
Add more sources for Austria:
- Kleine Zeitung
- Der Falter
- OOEN