### PR TITLE
Update kite_feeds.json with Times Colonist (BC, Canada)

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -602,6 +602,7 @@
       "https://www.theglobeandmail.com/arc/outboundfeeds/rss/category/canada/",
       "https://www.theifp.ca/search/?f=rss&t=article&c=news",
       "https://www.thestar.com/search/?f=rss&t=article&c=news/canada*&l=50&s=start_time&sd=desc",
+      "https://www.timescolonist.com/rss",
       "https://www.winnipegfreepress.com/canada/feed"
     ]
   },


### PR DESCRIPTION
The Times Colonist is an English-language daily newspaper in [Victoria](https://en.wikipedia.org/wiki/Victoria,_British_Columbia), the capital of British Columbia, Canada. It is the [oldest daily newspaper in Western Canada](https://www.timescolonist.com/other/about).

- https://www.timescolonist.com/
- https://en.wikipedia.org/wiki/Times_Colonist
