### PR TITLE
Add more sources to topic Brazil

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -524,7 +524,8 @@
       "https://www.gazetadopovo.com.br/feed/rss/brasil.xml",
       "https://news.google.com/rss/search?q=Brasil+site:reuters.com&hl=pt-BR&gl=BR&ceid=BR:pt",
       "https://veja.abril.com.br/feed/",
-      "https://oantagonista.com/feed/"
+      "https://oantagonista.com/feed/",
+      "https://jovempan.com.br/noticias/feed/"
     ]
   },
   "Canada": {


### PR DESCRIPTION
I've noticed that most sources are all leading to only one side of the political spectrum so I added more. 

Here, I used Kagi Research to validate the missing balance in sources: https://kagi.com/assistant/b5bbfbff-897f-4729-a809-19db0d120348 

Added a few more sources so that they are politically balanced (even though the ratio isn't ideal yet).

