### PR TITLE
Update Michigan Public RSS feed

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -4158,7 +4158,7 @@
       "https://www.lansingcitypulse.com/category/news/browse.rss",
       "https://www.metrotimes.com/feed/",
       "https://www.michigandaily.com/feed/",
-      "https://www.michiganpublic.org/index.rss",
+      "https://www.michiganpublic.org/news.rss",
       "https://www.record-eagle.com/search/?f=rss&t=article&c=news/local_news&l=50&s=start_time&sd=desc",
       "https://www.reddit.com/r/annarbor/.rss",
       "https://www.reddit.com/r/detroit/.rss",


### PR DESCRIPTION
The current RSS feed `index.rss` doesn't contain any news articles. The News section of the website uses `news.rss`.

Compare the item count of the two feeds:

```
$ curl -s https://www.michiganpublic.org/index.rss | grep "<item>" | wc -l
       0

$ curl -s https://www.michiganpublic.org/news.rss | grep "<item>" | wc -l
      10
```