### PR TITLE
Add abgeordnetenwatch.de Recherchen RSS feed for Germany

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1661,6 +1661,7 @@
     },
     "feeds": [
       "https://correctiv.org/feed/",
+      "https://www.abgeordnetenwatch.de/recherchen/feed",
       "https://jacobin.de/rss.xml",
       "https://katapult-magazin.de/feed/rss",
       "https://netzpolitik.org/feed/",


### PR DESCRIPTION
Adds the RSS feed from abgeordnetenwatch.de investigative section to the Germany feed list.