### PR TITLE
Remove nius.de - fails journalistic quality standards

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1667,7 +1667,6 @@
       "https://news.google.com/atom?hl=de-DE&gl=DE&ceid=DE:de",
       "https://news.google.com/atom/topics/CAAqIQgKIhtDQkFTRGdvSUwyMHZNRE0wTldnU0FtUmxLQUFQAQ?hl=de&gl=DE&ceid=DE:de",
       "https://newsfeed.zeit.de/all",
-      "https://nius.de/rss",
       "https://rp-online.de/feed.rss",
       "https://rss.sueddeutsche.de/rss/Alles",
       "https://taz.de/!p4608;rss/",


### PR DESCRIPTION
Removing nius.de from the feed list due to documented concerns about journalistic integrity:

- Political scientists and media researchers classify the outlet as deliberately using "manipulative methods of disinformation" and "post-factual presentation methods" (Linden, 2024)
- Facts are reportedly bent or omitted to fit a political agenda rather than pursuing truthful reporting (Rainer/Der Spiegel, 2024)
- The outlet is under investigation by Berlin-Brandenburg Media Authority for violations of journalistic standards

Sources:
- taz: https://taz.de/Rechtes-Medienportal-Nius/!5945019/
- BR24: https://www.br.de/nachrichten/netzwelt/warum-gibt-es-kritik-am-nachrichtenportal-nius,U4aJ8yf
- Deutschlandfunk: https://www.deutschlandfunk.de/medienaufsicht-prueft-offenbar-neues-portal-von-ex-bild-chef-julian-reichelt-100.html
- Tagesspiegel: https://www.tagesspiegel.de/politik/portal-von-reichelt-und-gotthardt-was-ist-nius--und-was-wird-den-machern-vorgeworfen-14208194.html
- Media Diversity Institute: https://www.media-diversity.org/nius-fox-news-in-german/