### PR TITLE
update category type for countries and cities

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -4339,7 +4339,7 @@
     ]
   },
   "USA | Colorado": {
-    "category_type": "city",
+    "category_type": "topic",
     "source_language": "en",
     "display_names": {
       "en": "USA | Colorado"


### PR DESCRIPTION
Update category type for countries and cities.
- added Colorado metadata

May want to add a State category or update city to be city/state/province.