### PR TITLE
Remove cairnsnews.org feed URL for Australia

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -294,7 +294,6 @@
       "http://feeds.perthherald.com/rss/12878be9fc2ca79c",
       "http://feeds.sydneysun.com/rss/ae0def0d9b645403",
       "http://www.16news.com.au/?feed=rss2",
-      "https://cairnsnews.org/feed/",
       "https://dynamicbusiness.com/feed.xml",
       "https://feeds.feedburner.com/com/rCTl",
       "https://feeds.feedburner.com/IndependentAustralia",


### PR DESCRIPTION
## Remove Cairns News Feed

This PR removes `https://cairnsnews.org/feed/` from the curated news sources.

### Reasoning

Cairns News is absolutely garbage and shouldn't be anywhere near a curated news feed. It's:

- **Rated as "Far-Right Biased" with "LOW" factual reporting**
- Publishes COVID conspiracy theories and anti-vax misinformation
- Sandy Hook trutherism
- QAnon content
- "Deep state" paranoia
- Anti-semitic globalist conspiracy theories
- Climate change denial

This site is mixing in with legitimate outlets like ABC, The Guardian, SMH, and SBS. That's completely inappropriate for a curated feed.

### Changes
- Removed `"https://cairnsnews.org/feed/"` from `kite_feeds.json`