### PR TITLE
Add Nintendo category with 32 RSS feeds

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -2790,6 +2790,7 @@
       "https://infendo.com/feed/",
       "https://kotaku.com/tag/nintendo/rss",
       "https://mynintendonews.com/feed/",
+      "https://news.google.com/rss/search?q=Nintendo&hl=en-US&gl=US&ceid=US:en",
       "https://news.google.com/rss/topics/CAAqKAgKIiJDQkFTRXdvTkwyY3ZNVEZvWmpBd2VYTndaeElDWlc0b0FBUAE?hl=en-US&gl=US&ceid=US%3Aen&oc=11",
       "https://news.google.com/rss/topics/CAAqKAgKIiJDQkFTRXdvTkwyY3ZNVEYzYUhCbVpIQndhaElDWlc0b0FBUAE?hl=en-US&gl=US&ceid=US%3Aen&oc=11",
       "https://nintendoeverything.com/feed/",


### PR DESCRIPTION
## Summary
Added new Nintendo topic category with 32 RSS feeds covering Nintendo news, hardware, and games.

## Feed sources
The category includes diverse coverage from:
- **Gaming news outlets**: IGN, GameSpot, Kotaku, GamesRadar, ComicBook
- **Nintendo-focused sites**: Nintendo Life, Nintendo Everything, Nintendo Wire, GoNintendo, My Nintendo News, Infendo, Pure Nintendo, Nintendo Insider, Nintendo World Report, Nintendojo, Vooks
- **Official source**: Nintendo UK news feed
- **Industry publications**: GamesIndustry.biz (Switch and Switch 2 tags)
- **Community forums**: Reddit (r/nintendo, r/NintendoSwitch, r/NintendoSwitch2, r/NintendoSwitchDeals, r/amiibo)
- **News aggregators**: Google News (Nintendo and gaming topics)
- **Analysis & commentary**: Source Gaming, Nintendo Link