### PR TITLE
Add iRacing & Sim Racing category with 26 RSS feeds

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -2000,7 +2000,8 @@
       "fr": "iRacing et Sim Racing",
       "it": "iRacing e Sim Racing",
       "ja": "iRacingとシムレーシング",
-      "pt": "iRacing e Sim Racing"
+      "pt": "iRacing e Sim Racing",
+      "zh-Hant": "iRacing 與模擬器賽車"
     },
     "feeds": [
       "https://boostedmedia.net/feed/",


### PR DESCRIPTION
## Summary
Added new iRacing & Sim Racing topic category with 26 RSS feeds covering sim racing news, hardware, and community updates.

## Feed sources
The category includes diverse coverage from:
- **Official sources**: iRacing.com (news and blog feeds)
- **Sim racing news outlets**: Overtake.gg, Traxion.gg, SimRaceNews.com, Sim Race Blog
- **Hardware & reviews**: Box This Lap, Sim Racing Cockpit, Apex Sim Racing
- **Technical guides**: Sim Racing Setup, Sim Racing Hub, iRacer Stuff
- **Industry coverage**: Boosted Media, iRacing Studios, bsimracing
- **Community forums**: Reddit (r/iRacing, r/simracing)
- **News aggregators**: Google News (iRacing and sim racing topics)