### PR TITLE
Add major AI company RSS feeds to AI category

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -190,7 +190,13 @@
       "https://www.wheresyoured.at/rss/",
       "https://www.wired.com/feed/tag/ai/latest/rss",
       "https://ysymyth.github.io/feed.xml",
-      "https://zed.dev/blog.rss"
+      "https://zed.dev/blog.rss",
+      "https://blog.google/products/gemini/rss/",
+      "https://news.google.com/rss/search?hl=en-US&gl=US&ceid=US%3Aen&oc=11&q=Anthropic",
+      "https://news.google.com/rss/search?hl=en-US&gl=US&ceid=US%3Aen&oc=11&q=Claude",
+      "https://news.google.com/rss/search?hl=en-US&gl=US&ceid=US%3Aen&oc=11&q=Mistral%20AI",
+      "https://news.google.com/rss/search?hl=en-US&gl=US&ceid=US%3Aen&oc=11&q=Le%20Chat",
+      "https://news.google.com/rss/search?hl=en-US&gl=US&ceid=US%3Aen&oc=11&q=Perplexity%20AI"
     ]
   },
   "Apple": {


### PR DESCRIPTION
## Summary

Addresses coverage gaps in the AI category by adding RSS feeds for major AI companies and tools that were underrepresented compared to OpenAI.

## Analysis & Rationale

The AI category included OpenAI's official RSS feed but lacked direct coverage of other major LLM providers and AI platforms.

**Missing Companies:**
- Anthropic (Claude) - Leading AI safety-focused LLM competitor to GPT
- Google Gemini - Google's flagship LLM product line
- Mistral AI - Major European open-source LLM provider
- Perplexity AI - AI-powered search engine using RAG

**Challenge:**
Many modern AI companies don't provide standard RSS feeds for their blogs/news pages (Anthropic, Mistral AI, Perplexity AI).

**Solution:**
- For companies with official RSS: Use direct feeds (Google Gemini)
- For companies without RSS: Use Google News search feeds as reliable aggregators

## Feeds Added

1. **Google Gemini Official Blog**: https://blog.google/products/gemini/rss/
2. **Anthropic News**: Google News search for "Anthropic"
3. **Claude News**: Google News search for "Claude"
4. **Mistral AI News**: Google News search for "Mistral AI"
5. **Le Chat News**: Google News search for "Le Chat"
6. **Perplexity AI News**: Google News search for "Perplexity AI"

This ensures balanced coverage of the major players in the current LLM landscape.