### PR TITLE
feat: add amerika21 as source for Latin American countries

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -855,7 +855,7 @@
       "zh-Hant": "哥倫比亞"
     },
     "feeds": [
-      "https://amerika21.de/geo/brasilien/feed",
+      "https://amerika21.de/geo/kolumbien/feed",
       "https://caracol.com.co/arc/outboundfeeds/rss/category/tendencias/?outputType=xml",
       "https://colombia.as.com/rss/",
       "https://colombiareports.com/feed/",


### PR DESCRIPTION
https://amerika21.de/ is a news site in German on Latin American countries.

There are Feeds available for all Latina American contries at `https://amerika21.de/geo/<contry_name>/feed`