### PR TITLE
Split search shortcut into separate keys

### DIFF
--- a/src/lib/components/search/SearchModal.svelte
+++ b/src/lib/components/search/SearchModal.svelte
@@ -556,7 +556,13 @@ $effect(() => {
             <kbd
               class="px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 rounded text-xs"
             >
-              {isMac ? "⌘" : "Ctrl"}K
+              {isMac ? '⌘' : 'Ctrl'}
+            </kbd>
+            <span>+</span>
+            <kbd
+              class="px-1.5 py-0.5 bg-gray-200 dark:bg-gray-700 rounded text-xs"
+            >
+              K
             </kbd>
             {s("search.search") || "search"}
           </span>


### PR DESCRIPTION
Summary from GitHub Copilot:

> This pull request makes a small UI improvement to the search modal keyboard shortcut display. The change clarifies the shortcut by visually separating the modifier key from the letter key, making it easier for users to understand.
> 
> * The keyboard shortcut display in `SearchModal.svelte` is updated to show the modifier key (`⌘` or `Ctrl`), a plus sign (`+`), and the letter `K` in separate elements for better clarity.

