### PR TITLE
Add Watches & Horology category with 30 RSS feeds

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -5445,7 +5445,22 @@
     "category_type": "topic",
     "source_language": "en",
     "display_names": {
-      "en": "Watches & Horology"
+      "en": "Watches & Horology",
+      "ar": "الساعات وعلم قياس الوقت",
+      "ca": "Rellotges i Rellotgeria",
+      "de": "Uhren & Uhrmacherkunst",
+      "es": "Relojes y Relojería",
+      "fr": "Montres et Horlogerie",
+      "he": "שעונים והורולוגיה",
+      "hi": "घड़ियाँ और होरोलॉजी",
+      "it": "Orologi e Orologeria",
+      "ja": "時計と時計学",
+      "nl": "Horloges & Horlogerie",
+      "pt": "Relógios e Relojoaria",
+      "ru": "Часы и Часовое дело",
+      "uk": "Годинники та Годинникарство",
+      "zh-Hans": "手表与钟表学",
+      "zh-Hant": "手錶與鐘錶"
     },
     "feeds": [
       "https://www.hodinkee.com/articles/rss.xml",


### PR DESCRIPTION
## Summary
- Adds comprehensive Watches & Horology category covering luxury timepieces, watchmaking craft, and industry news
- Established watch journalism blogs including Hodinkee, Monochrome Watches, SJX Watches, and WatchPro
- Diverse Reddit communities spanning vintage collecting, microbrands, haute horlogerie, and geographic perspectives (Japanese, Russian, Chinese watches)
- Specialized publications like Deployant, Haute Time, and Professional Watches
- Google News RSS feeds covering key industry topics: luxury watches, horology, vintage collecting, Swiss brands, and independent watchmakers