### PR TITLE
Add Google category with 41 feeds

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1934,7 +1934,7 @@
       "ru": "Google",
       "uk": "Google",
       "zh-Hans": "谷歌",
-      "zh-Hant": "谷歌"
+      "zh-Hant": "Google"
     },
     "feeds": [
       "https://9to5google.com/feed/",


### PR DESCRIPTION
## Summary
Adds a new Google category to complement the existing Apple and Microsoft categories.

## Feeds Coverage
- Official Google blogs (Android Developers, Chrome, Cloud, Research, Security, etc.)
- Tech news sites covering Google products (9to5Google, Ars Technica, TechCrunch, etc.)
- Google News RSS searches for key products (Android, Chrome, Pixel, Gemini, YouTube, etc.)
- Community sources (Reddit communities for Google products)

Total: 41 RSS feeds