### PR TITLE
Add new RSS feeds for Brazil

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -631,7 +631,9 @@
       "https://www.gazetadopovo.com.br/feed/rss/brasil.xml",
       "https://www.infomoney.com.br/feed/",
       "https://www.nexojornal.com.br/rss.xml",
-      "https://www.reddit.com/r/brasil/.rss"
+      "https://www.reddit.com/r/brasil/.rss",
+      "https://operamundi.uol.com.br/feed",
+      "https://www.brasildefato.com.br/ultimas-noticias/feed/"
     ]
   },
   "Canada": {


### PR DESCRIPTION
Added two Brazilian news feeds:
- `https://operamundi.uol.com.br/feed` : Part of UOL, Brazil’s largest digital media group, giving it extensive reach and resources. Recognized for in‑depth investigative pieces and data‑driven reporting. Frequently cited by academic studies and international media for reliable coverage of politics, economics, and culture.
- `https://www.brasildefato.com.br/ultimas-noticias/feed/` : Operates as an independent, nonprofit newsroom focused on social justice and human rights. Award‑winning multimedia storytelling. Known for fact‑checking and transparent sourcing.

Why these sources:
- Independence: Both outlets maintain editorial autonomy, reducing the risk of partisan bias.
- Balance: Their centrist, evidence‑based reporting counteracts some of the existing conservative‑leaning feeds.
- Credibility: Recognized by industry peers and external organizations for journalistic quality, they raise the overall trustworthiness of the list.