### PR TITLE
Add perspektive-online.net to rss feed germany

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1927,7 +1927,8 @@
       "https://www.t-online.de/nachrichten/feed.rss",
       "https://www.tagesschau.de/infoservices/alle-meldungen-100~rss2.xml",
       "https://www.tagesspiegel.de/contentexport/feed",
-      "https://www.zdf.de/rss/zdf/nachrichten"
+      "https://www.zdf.de/rss/zdf/nachrichten",
+      "https://perspektive-online.net/feed/"
     ]
   },
   "Germany | Hesse": {


### PR DESCRIPTION
Hi,

i would like to add perspektive-online.net to the germany news feed.
It's independent and left online and print newswebsite/newspaper.
More Infos(In Germany): https://perspektive-online.net/ueber-uns/  