### PR TITLE
Add Custom Frontend link for Pebble to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,4 +169,8 @@ Feel free to add new filter categories or improve existing ones by adding releva
 
 ## Custom front-ends
 
+### Raycast
 <a title="Install kagi-news Raycast Extension" href="https://www.raycast.com/mickaphd/kagi-news"><img src="https://www.raycast.com/mickaphd/kagi-news/install_button@2x.png?v=1.1" height="64" style="height: 64px;" alt=""></a>
+
+### Pebble
+<a title="Install Kagi News Pebble Application" href="https://apps.rebble.io/en_US/application/692b3f0549be450009b545ce"><img src="https://assets2.rebble.io/720x320/692d3f44d7dcba0009f1b174" height="100" alt=""></a>


### PR DESCRIPTION
I sort of winged this structure since it's now just the second Custom Frontend here. I figured putting the name of the platforms would be useful since I don't know that the first one is Raycast (or the second is Pebble) until I click on it but I'm open to changing any of it if it's an issue.

I'm also open to just putting a link, but Raycast's download link is image-y so I just mirrored that the best I could. 