### PR TITLE
Updated Estonian feeds to remove misinformation sources

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -1499,6 +1499,7 @@
       "https://sonumitooja.ee/feed/",
       "https://tartu.postimees.ee/rss",
       "https://tehnika.postimees.ee/rss",
+      "https://uueduudised.ee/feed/",
       "https://virumaateataja.postimees.ee/rss",
       "https://www.am.ee/rss.xml",
       "https://www.aripaev.ee/rss",


### PR DESCRIPTION
Greetings from Estonia!

You guys did a great job gathering Estonian sources for news. However, there's a few errors that I would consider not being index worthy. Both sites, telegram.ee and uueduudised.ee are known for spreading Russian propaganda, pseudoscience and conspiracy theories. The other sources work well to create a neutral view of things.

I would've not noticed the two sources if I had not received articles referenced from the given sites though and these two are definitely sites I don't ever want to see mentioned when reading the news.

See for example:
https://www.propastop.org/en/2024/02/20/telegram-ee-spreads-misinformation-about-the-plan-to-send-reservists-to-the-war-in-ukraine/

Also added Propastop feed to counter-weight against misinformation.

See:
https://news.postimees.ee/7805189/propastop-awarded-european-citizen-s-prize

Thanks!