### PR TITLE
Added category: MMA

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -4030,7 +4030,6 @@
       "https://www.mmaweekly.com/.rss/full/",
       "https://www.lowkickmma.com/feed/",
       "https://mymmanews.com/feed/",
-      "https://www.sherdog.com/rss/news.xml",
       "https://mmauk.net/feed/",
       "https://mmastalker.com/feed/",
       "https://www.extrememma.com.au/feed/",


### PR DESCRIPTION
I would like to add a category for MMA.
Mainly for UFC, URLs should all work, and there hopefully is significant enough overlap for UFC news and events.
RSS feeds for MMA are not easy to find. The feeds could also be added to sports in general, but it would be nice to have a seperate category I think.

Category names have just been added as MMA for all languages, feed sources should all be in English.