### PR TITLE
Add Kinmen local feeds to Taiwan category to improve geopolitical coverage

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -6067,7 +6067,9 @@
       "https://www.twse.com.tw/rwd/zh/news/feed?type=rss",
       "https://www.voh.com.tw/tw/Home/ugC_RSS.aspx",
       "https://www.worldjournal.com/wj/rssfeed/121098",
-      "https://www.ydn.com.tw/tw/Home/RSS.aspx?TID=4"
+      "https://www.ydn.com.tw/tw/Home/RSS.aspx?TID=4",
+      "https://www.kinmen.gov.tw/OpenData.aspx?SN=CF5DF99964D9DB8E",
+      "https://www.kmdn.gov.tw/1117/1271/1272/RSSList"
     ]
   },
   "Thailand": {


### PR DESCRIPTION
Added local news sources from Kinmen County (金門) to the Taiwan category.

**Reasoning:**
Kinmen holds a unique and critical geopolitical position between Taiwan and China. Due to recent cross-strait tensions, relying solely on mainstream media often leads to a lack of on-the-ground perspectives from the frontline.

Adding these local official and daily news feeds helps bridge this information gap and provides more diverse, decentralized signals regarding the region.

**Feeds added:**
1. Kinmen County Government Event Alerts (OpenData)
2. Kinmen Daily News (Local News)