### PR TITLE
chore: update feeds by removing outdated links and adding new sources

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -3101,7 +3101,6 @@
       "https://eleftherostypos.gr/feed",
       "https://feeds.feedburner.com/dikaiologitika/ZteV",
       "https://feeds.feedburner.com/kathimerini/DJpy",
-      "https://fyi.news/feed/",
       "https://prin.gr/feed/",
       "https://thepressproject.gr/feed/",
       "https://wearesolomon.com/el/feed/",
@@ -3437,8 +3436,7 @@
       "https://www.reddit.com/r/Madurai/.rss",
       "https://www.reddit.com/r/southindianfashion/.rss",
       "https://www.reddit.com/r/tamil/.rss",
-      "https://www.reddit.com/r/tamilnadu/.rss",
-      "https://www.vikatan.com/rss/tamilnadu"
+      "https://www.reddit.com/r/tamilnadu/.rss"
     ]
   },
   "Iran": {
@@ -4588,7 +4586,8 @@
       "https://www.profootballnetwork.com/feed/",
       "https://www.rotowire.com/rss/news.php?sport=NFL",
       "https://www.thecoldwire.com/sports/nfl/feed/",
-      "https://www.yardbarker.com/rss/sport_merged/2"
+      "https://www.yardbarker.com/rss/sport_merged/2",
+      "https://www.sbnation.com/rss/nfl/index.xml"
     ]
   },
   "NHL": {


### PR DESCRIPTION
This pull request updates the `kite_feeds.json` file by modifying several RSS feed sources for different regions and categories. The main changes involve removing outdated or duplicate feeds and adding new relevant sources.

Feed source updates:

* Removed the `https://fyi.news/feed/` RSS feed from the list 
* Adjusted the Tamil Nadu feeds by removing the `https://www.vikatan.com/rss/tamilnadu` feed and ensuring only the `https://www.reddit.com/r/tamilnadu/.rss` feed is included, avoiding duplication.

Sports feed enhancements:

* Added the `https://www.sbnation.com/rss/nfl/index.xml` feed to the NFL section to broaden coverage, and ensured the `https://www.yardbarker.com/rss/sport_merged/2` feed remains included.