### PR TITLE
Filter Null/Empty Strings in Talking Points JSON to Prevent TypeError

### DIFF
--- a/src/lib/components/story/StoryHighlights.svelte
+++ b/src/lib/components/story/StoryHighlights.svelte
@@ -24,8 +24,9 @@ let { points = [], articles = [], citationMapping, storyLocalizer = s, flashcard
 
 // Convert citations to numbered format if mapping is available
 const displayPoints = $derived.by(() => {
-	if (!citationMapping) return points;
-	return points.map((point) => replaceWithNumberedCitations(point, citationMapping));
+  const filteredPoints = points.filter((point) => typeof point === 'string' && point.trim().length > 0);
+	if (!citationMapping) return filteredPoints;
+	return filteredPoints.map((point) => replaceWithNumberedCitations(point, citationMapping));
 });
 </script>
 


### PR DESCRIPTION
This PR addresses a recent Issue I created here:
https://github.com/kagisearch/kite-public/issues/411

Where null values in the `stories.talking_points` string array can eventually result in `colonSplitter` throwing a TypeError when it attempts to access `text.length`, where `text` is `null`. This breaks everything until the client refreshes.

I'm now able to expand the originally-problematic article:

<img width="1151" height="737" alt="image" src="https://github.com/user-attachments/assets/4dba3cb3-a6ff-4b4b-921d-8533c684f42f" />
