### PR TITLE
Update hungarian sources

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -3341,6 +3341,15 @@
       "zh-Hant": "匈牙利"
     },
     "feeds": [
+      "http://24ora.index.hu/?rss&&rovatkeres=osszes",
+      "https://www.portfolio.hu/rss/all.xml",
+      "https://www.penzcentrum.hu/rss/all.xml",
+      "https://tozsdeforum.hu/feed/",
+      "https://www.nytimes.com/svc/collections/v1/publish/https://www.nytimes.com/topic/destination/hungary/rss.xml",
+      "https://news.google.com/rss/topics/CAAqIQgKIhtDQkFTRGdvSUwyMHZNRE5uYWpJU0FtaDFLQUFQAQ?hl=hu&gl=HU&ceid=HU%3Ahu",
+      "https://nepszava.hu/rss",
+      "https://www.vg.hu/publicapi/hu/rss/vilaggazdasag/articles",
+      "https://www.valaszonline.hu/feed/",
       "http://koznews.hu/rss.xml",
       "https://168.hu/rss",
       "https://24.hu/rss",
@@ -3359,10 +3368,8 @@
       "https://politepol.com/fd/FqZhiMYQ0GIl.xml",
       "https://rss.hirkereso.hu/",
       "https://telex.hu/rss",
-      "https://telex.hu/rss/archivum?filters=%7B%22and_tags%22%3A%5B%5D%2C%22superTags%22%3A%5B%22G7%22%5D%2C%22authors%22%3A%5B%5D%2C%22title%22%3A%5B%5D%7D&perPage=20",
       "https://www.direkt36.hu/rss",
       "https://www.hirstart.hu/site/publicrss.php?pos=balrovat&pid=7",
-      "https://www.magyarkurir.hu/rss",
       "https://www.police.hu/hu/rss/feed",
       "https://www.reddit.com/r/hungary/best/.rss",
       "https://www.theguardian.com/world/hungary/rss"


### PR DESCRIPTION
I've updated the hungarian news sources.

Added sources:
- 24ora.index.hu
- portfolio.hu
- penzcentrum.hu
- tozsdeforum.hu
- nytimes.com - hungarian section
- news.google.com - hungarian section
- nepszava.hu
- vg.hu
- valaszonline.hu
