### PR TITLE
add French Sports and French Soccer category

### DIFF
--- a/kite_feeds.json
+++ b/kite_feeds.json
@@ -6329,6 +6329,45 @@
       "https://www.yardbarker.com/rss/sport_merged/11"
     ]
   },
+  "French Football": {
+    "category_type": "topic",
+    "source_language": "fr",
+    "display_names": {
+      "en": "French Soccer",
+      "fr": "Football Français",
+      "de": "Französischer Fußball",
+      "es": "Fútbol Francés",
+      "it": "Calcio Francese",
+      "pt": "Futebol Francês",
+      "zh-Hans": "法国足球",
+      "zh-Hant": "法國足球",
+      "ja": "フランスサッカー",
+      "ru": "Французский футбол",
+      "ar": "كرة القدم الفرنسية",
+      "he": "כדורגל צרפתי",
+      "hi": "फ्रेंच फुटबॉल",
+      "nl": "Frans voetbal",
+      "et": "Prantsuse jalgpall",
+      "ca": "Futbol Francès",
+      "uk": "Французький футбол"
+    },
+    "feeds": [
+      "https://partner-feeds.20min.ch/rss/20minutes/sports/football",
+      "https://www.franceinfo.fr/sports/foot.rss",
+      "https://france3-regions.franceinfo.fr/sport/football/ligue-1/rss",
+      "https://france3-regions.franceinfo.fr/sport/football/ligue-2/rss",
+      "https://rmcsport.bfmtv.com/rss/football/",
+      "https://www.sudouest.fr/sport/football/rss.xml",
+      "https://www.liberation.fr/arc/outboundfeeds/rss/category/sports/football/?outputType=xml",
+      "https://www.lemonde.fr/football/rss_full.xml",
+      "https://www.lefigaro.fr/rss/figaro_football.xml",
+      "https://feeds.leparisien.fr/leparisien/rss/sports/football",
+      "https://www.lindependant.fr/sport/football/rss.xml",
+      "https://dwh.lequipe.fr/api/edito/rss?path=/Football/",
+      "https://www.letelegramme.fr/sports/football/rss.xml",
+      "https://www.sports.fr/football/feed"
+    ]
+  },
   "South Korea": {
     "category_type": "topic",
     "source_language": "ko",


### PR DESCRIPTION
This pull request adds two new French-language sports categories to the `kite_feeds.json` configuration, expanding coverage of French sports news and football (soccer) from a variety of sources. These additions enhance the platform's international sports content.

New French sports categories:

* Added a "French Sports" topic with multilingual display names and a comprehensive list of French-language sports news RSS feeds.
* Added a "French Football" topic with multilingual display names and a focused set of French-language football (soccer) RSS feeds.This pull request adds a new topic category for French sports news feeds to the `kite_feeds.json` configuration. This enhances the application's coverage of sports content in the French language by aggregating multiple reputable sources.

New content addition:

* Added a "French Sports" topic to `kite_feeds.json`, including multilingual display names and a curated list of French-language sports news RSS feeds.